### PR TITLE
Prevent sending goroutine to block after timeout

### DIFF
--- a/geocoder.go
+++ b/geocoder.go
@@ -44,7 +44,7 @@ type Geocoder struct {
 
 // Geocode returns location for address
 func (g Geocoder) Geocode(address string) (Location, error) {
-	ch := make(chan Location)
+	ch := make(chan Location, 1)
 	go func() {
 		response(g.GeocodeURL(url.QueryEscape(address)), g.ResponseObject())
 		ch <- g.Location()
@@ -60,7 +60,7 @@ func (g Geocoder) Geocode(address string) (Location, error) {
 
 // ReverseGeocode returns address for location
 func (g Geocoder) ReverseGeocode(lat, lng float64) (string, error) {
-	ch := make(chan string)
+	ch := make(chan string, 1)
 	go func() {
 		response(g.ReverseGeocodeURL(Location{lat, lng}), g.ResponseObject())
 		ch <- g.Address()


### PR DESCRIPTION
The channel ch needs a buffer size of 1. If it were an unbuffered
channel and the response took more than timeoutInSeconds, the channel
send statement [e.g. ch <- g.Location()] would block forever as there
is no receiver anymore. The sending goroutine would never be
destroyed by the garbage collector.
See: https://github.com/golang/go/wiki/Timeouts