### PR TITLE
Test use environment variables for API keys

### DIFF
--- a/bing/geocoder_test.go
+++ b/bing/geocoder_test.go
@@ -3,11 +3,12 @@ package bing_test
 import (
 	"github.com/codingsince1985/geo-golang"
 	"github.com/codingsince1985/geo-golang/bing"
+	"os"
 	"strings"
 	"testing"
 )
 
-const key = "YOUR_KEY"
+var key = os.Getenv("BING_API_KEY")
 
 var geocoder = bing.Geocoder(key)
 

--- a/google/geocoder.go
+++ b/google/geocoder.go
@@ -1,27 +1,28 @@
-// Package google is a geo-golang based Google Maps geocode/reverse geocode client
+// Package google is a geo-golang based Google Geo Location API
+// https://developers.google.com/maps/documentation/geocoding/intro
 package google
 
 import (
 	"fmt"
-	"github.com/codingsince1985/geo-golang"
+	geo "github.com/codingsince1985/geo-golang"
 )
 
 type baseURL string
 
 type geocodeResponse struct {
 	Results []struct {
-		Formatted_Address string
-		Geometry          struct {
+		FormattedAddress string `json:"formatted_address"`
+		Geometry         struct {
 			Location geo.Location
 		}
 	}
 }
 
 // Geocoder constructs Google geocoder
-func Geocoder() geo.Geocoder {
+func Geocoder(apiKey string) geo.Geocoder {
 	return geo.Geocoder{
-		baseURL("http://maps.googleapis.com/maps/api/geocode/json?sensor=false&"),
-		&geocodeResponse{},
+		EndpointBuilder: baseURL(fmt.Sprintf("https://maps.googleapis.com/maps/api/geocode/json?&key=%s&", apiKey)),
+		ResponseParser:  &geocodeResponse{},
 	}
 }
 
@@ -42,7 +43,7 @@ func (r *geocodeResponse) Location() (l geo.Location) {
 
 func (r *geocodeResponse) Address() (address string) {
 	if len(r.Results) > 0 {
-		address = r.Results[0].Formatted_Address
+		address = r.Results[0].FormattedAddress
 	}
 	return
 }

--- a/google/geocoder_test.go
+++ b/google/geocoder_test.go
@@ -7,7 +7,9 @@ import (
 	"testing"
 )
 
-var geocoder = google.Geocoder()
+const token = "YOUR_ACCESS_TOKEN"
+
+var geocoder = google.Geocoder(token)
 
 func TestGeocode(t *testing.T) {
 	if location, err := geocoder.Geocode("Melbourne VIC"); err != nil || location.Lat != -37.814107 || location.Lng != 144.96328 {

--- a/google/geocoder_test.go
+++ b/google/geocoder_test.go
@@ -3,11 +3,12 @@ package google_test
 import (
 	"github.com/codingsince1985/geo-golang"
 	"github.com/codingsince1985/geo-golang/google"
+	"os"
 	"strings"
 	"testing"
 )
 
-const token = "YOUR_ACCESS_TOKEN"
+var token = os.Getenv("GOOGLE_API_KEY")
 
 var geocoder = google.Geocoder(token)
 

--- a/here/geocoder_test.go
+++ b/here/geocoder_test.go
@@ -3,12 +3,13 @@ package here_test
 import (
 	"github.com/codingsince1985/geo-golang"
 	"github.com/codingsince1985/geo-golang/here"
+	"os"
 	"strings"
 	"testing"
 )
 
-const appID = "YOUR_APP_ID"
-const appCode = "YOUR_APP_CODE"
+var appID = os.Getenv("HERE_APP_ID")
+var appCode = os.Getenv("HERE_APP_CODE")
 
 var geocoder = here.Geocoder(appID, appCode, 100)
 

--- a/mapbox/geocoder_test.go
+++ b/mapbox/geocoder_test.go
@@ -3,11 +3,12 @@ package mapbox_test
 import (
 	"github.com/codingsince1985/geo-golang"
 	"github.com/codingsince1985/geo-golang/mapbox"
+	"os"
 	"strings"
 	"testing"
 )
 
-const token = "YOUR_ACCESS_TOKEN"
+var token = os.Getenv("MAPBOX_API_KEY")
 
 var geocoder = mapbox.Geocoder(token)
 

--- a/mapquest/nominatim/geocoder_test.go
+++ b/mapquest/nominatim/geocoder_test.go
@@ -3,11 +3,12 @@ package nominatim_test
 import (
 	"github.com/codingsince1985/geo-golang"
 	"github.com/codingsince1985/geo-golang/mapquest/nominatim"
+	"os"
 	"strings"
 	"testing"
 )
 
-const key = "YOUR_KEY"
+var key = os.Getenv("NOMINATUM_KEY")
 
 var geocoder = nominatim.Geocoder(key)
 

--- a/mapquest/open/geocoder_test.go
+++ b/mapquest/open/geocoder_test.go
@@ -3,11 +3,12 @@ package open_test
 import (
 	"github.com/codingsince1985/geo-golang"
 	"github.com/codingsince1985/geo-golang/mapquest/open"
+	"os"
 	"strings"
 	"testing"
 )
 
-const key = "YOUR_KEY"
+var key = os.Getenv("MAPQUEST_OPEN_KEY")
 
 var geocoder = open.Geocoder(key)
 

--- a/opencage/geocoder_test.go
+++ b/opencage/geocoder_test.go
@@ -3,11 +3,12 @@ package opencage_test
 import (
 	"github.com/codingsince1985/geo-golang"
 	"github.com/codingsince1985/geo-golang/opencage"
+	"os"
 	"strings"
 	"testing"
 )
 
-const key = "YOUR_KEY"
+var key = os.Getenv("OPENCAGE_API_KEY")
 
 var geocoder = opencage.Geocoder(key)
 


### PR DESCRIPTION
Depends on #2 

Specify test API keys using environment variables e.g.

```shell
GOOGLE_API_KEY="XYZ" go test -v ./google
```