### PR TITLE
Removes duplicated code in openstreetmap.Geocoder()

### DIFF
--- a/openstreetmap/geocoder.go
+++ b/openstreetmap/geocoder.go
@@ -19,10 +19,7 @@ type geocodeResponse struct {
 
 // Geocoder constructs OpenStreetMap geocoder
 func Geocoder() geo.Geocoder {
-	return geo.HTTPGeocoder{
-		EndpointBuilder:       baseURL("https://nominatim.openstreetmap.org/"),
-		ResponseParserFactory: func() geo.ResponseParser { return &geocodeResponse{} },
-	}
+	return GeocoderWithURL("https://nominatim.openstreetmap.org/")
 }
 
 // GeocoderWithURL constructs OpenStreetMap geocoder using a custom installation of Nominatim


### PR DESCRIPTION
As requested in #22 , this removes the duplicated code in `openstreetmap.Geocoder()`.