### PR TITLE
Add structured address

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 sudo: false
 go:
-- '1.5'
+- '1.7'
 - tip
 go_import_path: github.com/codingsince1985/geo-golang
 before_install:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 GeoService in Go
 ==
-[![GoDoc](https://godoc.org/github.com/codingsince1985/geo-golang?status.svg)](https://godoc.org/github.com/codingsince1985/geo-golang) [![Build Status](https://travis-ci.org/codingsince1985/geo-golang.svg?branch=master)](https://travis-ci.org/codingsince1985/geo-golang) 
+[![GoDoc](https://godoc.org/github.com/codingsince1985/geo-golang?status.svg)](https://godoc.org/github.com/codingsince1985/geo-golang) [![Build Status](https://travis-ci.org/codingsince1985/geo-golang.svg?branch=master)](https://travis-ci.org/codingsince1985/geo-golang)
 [![codecov](https://codecov.io/gh/codingsince1985/geo-golang/branch/master/graph/badge.svg)](https://codecov.io/gh/codingsince1985/geo-golang)
 [![Go Report Card](https://goreportcard.com/badge/codingsince1985/geo-golang)](https://goreportcard.com/report/codingsince1985/geo-golang)
 
@@ -51,11 +51,15 @@ const (
 )
 
 func main() {
+	ExampleGeocoder()
+}
+
+func ExampleGeocoder() {
 	fmt.Println("Google Geocoding API")
 	try(google.Geocoder(os.Getenv("GOOGLE_API_KEY")))
 
 	fmt.Println("Mapquest Nominatim")
-	try(nominatim.Geocoder(os.Getenv("MAPQUEST_NOMINATUM_KEY")))
+	try(nominatim.Geocoder(os.Getenv("MAPQUEST_NOMINATIM_KEY")))
 
 	fmt.Println("Mapquest Open streetmaps")
 	try(open.Geocoder(os.Getenv("MAPQUEST_OPEN_KEY")))
@@ -74,7 +78,7 @@ func main() {
 
 	fmt.Println("OpenStreetMap")
 	try(openstreetmap.Geocoder())
-	
+
 	fmt.Println("LocationIQ")
 	try(locationiq.Geocoder(os.Getenv("LOCATIONIQ_API_KEY"), ZOOM))
 
@@ -88,52 +92,72 @@ func main() {
 
 func try(geocoder geo.Geocoder) {
 	location, _ := geocoder.Geocode(addr)
-	fmt.Printf("%s location is %v\n", addr, location)
+	if location != nil {
+		fmt.Printf("%s location is (%.6f, %.6f)\n", addr, location.Lat, location.Lng)
+	} else {
+		fmt.Println("got <nil> location")
+	}
 	address, _ := geocoder.ReverseGeocode(lat, lng)
-	fmt.Printf("Address of (%f,%f) is %s\n\n", lat, lng, address)
+	if address != nil {
+		fmt.Printf("Address of (%.6f,%.6f) is %s\n", lat, lng, address.FormattedAddress)
+		fmt.Printf("Detailed address: %#v\n", address)
+	} else {
+		fmt.Println("got <nil> address")
+	}
+	fmt.Println("\n")
 }
 ```
 ###Result
 ```
 Google Geocoding API
 Melbourne VIC location is (-37.813611, 144.963056)
-Address of (-37.813611,144.963056) is 350 Bourke St, Melbourne VIC 3004, Australia
+Address of (-37.813611,144.963056) is 197 Elizabeth St, Melbourne VIC 3000, Australia
+Detailed address: &geo.Address{FormattedAddress:"197 Elizabeth St, Melbourne VIC 3000, Australia", Street:"Elizabeth Street", HouseNumber:"197", Suburb:"", Postcode:"3000", State:"Victoria", StateDistrict:"Melbourne City", County:"", Country:"Australia", CountryCode:"AU", City:"Melbourne"}
 
 Mapquest Nominatim
 Melbourne VIC location is (-37.814218, 144.963161)
-Address of (-37.813611,144.963056) is Melbourne's GPO, Postal Lane, Chinatown, Melbourne, City of Melbourne, Greater Melbourne, Victoria, 3000, Australia
+Address of (-37.813611,144.963056) is Melbourne's GPO, Postal Lane, Melbourne, City of Melbourne, Greater Melbourne, Victoria, 3000, Australia
+Detailed address: &geo.Address{FormattedAddress:"Melbourne's GPO, Postal Lane, Melbourne, City of Melbourne, Greater Melbourne, Victoria, 3000, Australia", Street:"Postal Lane", HouseNumber:"", Suburb:"Melbourne", Postcode:"3000", State:"Victoria", StateDistrict:"", County:"City of Melbourne", Country:"Australia", CountryCode:"AU", City:"Melbourne"}
 
 Mapquest Open streetmaps
 Melbourne VIC location is (-37.814218, 144.963161)
-Address of (-37.813611,144.963056) is Postal Lane, Melbourne, Victoria, AU
+Address of (-37.813611,144.963056) is Elizabeth Street, 3000, Melbourne, Victoria, AU
+Detailed address: &geo.Address{FormattedAddress:"Elizabeth Street, 3000, Melbourne, Victoria, AU", Street:"Elizabeth Street", HouseNumber:"", Suburb:"", Postcode:"3000", State:"Victoria", StateDistrict:"", County:"", Country:"", CountryCode:"AU", City:"Melbourne"}
 
 OpenCage Data
 Melbourne VIC location is (-37.814217, 144.963161)
 Address of (-37.813611,144.963056) is Melbourne's GPO, Postal Lane, Melbourne VIC 3000, Australia
+Detailed address: &geo.Address{FormattedAddress:"Melbourne's GPO, Postal Lane, Melbourne VIC 3000, Australia", Street:"Postal Lane", HouseNumber:"", Suburb:"Melbourne (3000)", Postcode:"3000", State:"Victoria", StateDistrict:"", County:"City of Melbourne", Country:"Australia", CountryCode:"AU", City:"Melbourne"}
 
 HERE API
 Melbourne VIC location is (-37.817530, 144.967150)
 Address of (-37.813611,144.963056) is 197 Elizabeth St, Melbourne VIC 3000, Australia
+Detailed address: &geo.Address{FormattedAddress:"197 Elizabeth St, Melbourne VIC 3000, Australia", Street:"Elizabeth St", HouseNumber:"197", Suburb:"", Postcode:"3000", State:"Victoria", StateDistrict:"", County:"", Country:"Australia", CountryCode:"AUS", City:"Melbourne"}
 
 Bing Geocoding API
 Melbourne VIC location is (-37.824299, 144.977997)
 Address of (-37.813611,144.963056) is Elizabeth St, Melbourne, VIC 3000
+Detailed address: &geo.Address{FormattedAddress:"Elizabeth St, Melbourne, VIC 3000", Street:"Elizabeth St", HouseNumber:"", Suburb:"", Postcode:"3000", State:"", StateDistrict:"", County:"", Country:"Australia", CountryCode:"", City:"Melbourne"}
 
 Mapbox API
 Melbourne VIC location is (-37.814200, 144.963200)
-Address of (-37.813611,144.963056) is Elwood Park Playground, 3000 Melbourne, Australia
+Address of (-37.813611,144.963056) is Elwood Park Playground, Melbourne, Victoria 3000, Australia
+Detailed address: &geo.Address{FormattedAddress:"Elwood Park Playground, Melbourne, Victoria 3000, Australia", Street:"Elwood Park Playground", HouseNumber:"", Suburb:"", Postcode:"3000", State:"Victoria", StateDistrict:"", County:"", Country:"Australia", CountryCode:"AU", City:"Melbourne"}
 
 OpenStreetMap
 Melbourne VIC location is (-37.814217, 144.963161)
 Address of (-37.813611,144.963056) is Melbourne's GPO, Postal Lane, Chinatown, Melbourne, City of Melbourne, Greater Melbourne, Victoria, 3000, Australia
+Detailed address: &geo.Address{FormattedAddress:"Melbourne's GPO, Postal Lane, Chinatown, Melbourne, City of Melbourne, Greater Melbourne, Victoria, 3000, Australia", Street:"Postal Lane", HouseNumber:"", Suburb:"Melbourne", Postcode:"3000", State:"Victoria", StateDistrict:"", County:"", Country:"Australia", CountryCode:"AU", City:"Melbourne"}
 
 LocationIQ
 Melbourne VIC location is (-37.814217, 144.963161)
 Address of (-37.813611,144.963056) is Melbourne's GPO, Postal Lane, Chinatown, Melbourne, City of Melbourne, Greater Melbourne, Victoria, 3000, Australia
+Detailed address: &geo.Address{FormattedAddress:"Melbourne's GPO, Postal Lane, Chinatown, Melbourne, City of Melbourne, Greater Melbourne, Victoria, 3000, Australia", Street:"Postal Lane", HouseNumber:"", Suburb:"Melbourne", Postcode:"3000", State:"Victoria", StateDistrict:"", County:"", Country:"Australia", CountryCode:"AU", City:"Melbourne"}
 
 ChainedAPI[OpenStreetmap -> Google]
 Melbourne VIC location is (-37.814217, 144.963161)
 Address of (-37.813611,144.963056) is Melbourne's GPO, Postal Lane, Chinatown, Melbourne, City of Melbourne, Greater Melbourne, Victoria, 3000, Australia
+Detailed address: &geo.Address{FormattedAddress:"Melbourne's GPO, Postal Lane, Chinatown, Melbourne, City of Melbourne, Greater Melbourne, Victoria, 3000, Australia", Street:"Postal Lane", HouseNumber:"", Suburb:"Melbourne", Postcode:"3000", State:"Victoria", StateDistrict:"", County:"", Country:"Australia", CountryCode:"AU", City:"Melbourne"}
 ```
 License
 ==

--- a/bing/geocoder.go
+++ b/bing/geocoder.go
@@ -2,6 +2,7 @@
 package bing
 
 import (
+	"errors"
 	"fmt"
 	"github.com/codingsince1985/geo-golang"
 	"strings"
@@ -17,9 +18,16 @@ type (
 				}
 				Address struct {
 					FormattedAddress string
+					AddressLine      string
+					AdminDistrict    string
+					AdminDistrict2   string
+					CountryRegion    string
+					Locality         string
+					PostalCode       string
 				}
 			}
 		}
+		ErrorDetails []string
 	}
 )
 
@@ -46,17 +54,28 @@ func (b baseURL) ReverseGeocodeURL(l geo.Location) string {
 	return strings.Replace(string(b), "*", fmt.Sprintf("/%f,%f?", l.Lat, l.Lng), 1)
 }
 
-func (r *geocodeResponse) Location() geo.Location {
-	if len(r.ResourceSets) == 0 || len(r.ResourceSets[0].Resources) == 0 {
-		return geo.Location{}
+func (r *geocodeResponse) Location() (*geo.Location, error) {
+	if len(r.ResourceSets) <= 0 || len(r.ResourceSets[0].Resources) <= 0 {
+		return nil, fmt.Errorf("empty result resolving location")
 	}
 	c := r.ResourceSets[0].Resources[0].Point.Coordinates
-	return geo.Location{c[0], c[1]}
+	return &geo.Location{c[0], c[1]}, nil
 }
 
-func (r *geocodeResponse) Address() string {
-	if len(r.ResourceSets) == 0 || len(r.ResourceSets[0].Resources) == 0 {
-		return ""
+func (r *geocodeResponse) Address() (*geo.Address, error) {
+	if len(r.ErrorDetails) > 0 {
+		return nil, errors.New(strings.Join(r.ErrorDetails, " "))
 	}
-	return r.ResourceSets[0].Resources[0].Address.FormattedAddress
+	if len(r.ResourceSets) <= 0 || len(r.ResourceSets[0].Resources) <= 0 {
+		return nil, nil
+	}
+	//fmt.Printf("%+v\n\n", r.ResourceSets[0].Resources[0].Address)
+	a := r.ResourceSets[0].Resources[0].Address
+	return &geo.Address{
+		FormattedAddress: a.FormattedAddress,
+		Street:           a.AddressLine,
+		City:             a.Locality,
+		Postcode:         a.PostalCode,
+		Country:          a.CountryRegion,
+	}, nil
 }

--- a/bing/geocoder.go
+++ b/bing/geocoder.go
@@ -56,10 +56,13 @@ func (b baseURL) ReverseGeocodeURL(l geo.Location) string {
 
 func (r *geocodeResponse) Location() (*geo.Location, error) {
 	if len(r.ResourceSets) <= 0 || len(r.ResourceSets[0].Resources) <= 0 {
-		return nil, fmt.Errorf("empty result resolving location")
+		return nil, nil
 	}
 	c := r.ResourceSets[0].Resources[0].Point.Coordinates
-	return &geo.Location{c[0], c[1]}, nil
+	return &geo.Location{
+		Lat: c[0],
+		Lng: c[1],
+	}, nil
 }
 
 func (r *geocodeResponse) Address() (*geo.Address, error) {
@@ -69,7 +72,7 @@ func (r *geocodeResponse) Address() (*geo.Address, error) {
 	if len(r.ResourceSets) <= 0 || len(r.ResourceSets[0].Resources) <= 0 {
 		return nil, nil
 	}
-	//fmt.Printf("%+v\n\n", r.ResourceSets[0].Resources[0].Address)
+
 	a := r.ResourceSets[0].Resources[0].Address
 	return &geo.Address{
 		FormattedAddress: a.FormattedAddress,

--- a/bing/geocoder.go
+++ b/bing/geocoder.go
@@ -4,8 +4,9 @@ package bing
 import (
 	"errors"
 	"fmt"
-	"github.com/codingsince1985/geo-golang"
 	"strings"
+
+	"github.com/codingsince1985/geo-golang"
 )
 
 type (

--- a/bing/geocoder_test.go
+++ b/bing/geocoder_test.go
@@ -1,15 +1,15 @@
 package bing_test
 
 import (
-	"fmt"
-	"github.com/codingsince1985/geo-golang"
-	"github.com/codingsince1985/geo-golang/bing"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/codingsince1985/geo-golang"
+	"github.com/codingsince1985/geo-golang/bing"
+	"github.com/stretchr/testify/assert"
 )
 
 var key = os.Getenv("BING_API_KEY")
@@ -20,9 +20,9 @@ func TestGeocode(t *testing.T) {
 
 	geocoder := bing.Geocoder(key, ts.URL+"/")
 	location, err := geocoder.Geocode("60 Collins St, Melbourne VIC")
+
 	assert.NoError(t, err)
-	fmt.Println(location)
-	assert.Equal(t, geo.Location{Lat: -37.81375, Lng: 144.97176}, location)
+	assert.Equal(t, geo.Location{Lat: -37.81375, Lng: 144.97176}, *location)
 }
 
 func TestReverseGeocode(t *testing.T) {
@@ -31,9 +31,9 @@ func TestReverseGeocode(t *testing.T) {
 
 	geocoder := bing.Geocoder(key, ts.URL+"/")
 	address, err := geocoder.ReverseGeocode(-37.81375, 144.97176)
+
 	assert.NoError(t, err)
-	fmt.Println(address)
-	assert.True(t, strings.Index(address, "Collins St") > 0)
+	assert.True(t, strings.Index(address.FormattedAddress, "Collins St") > 0)
 }
 
 func TestReverseGeocodeWithNoResult(t *testing.T) {
@@ -41,8 +41,10 @@ func TestReverseGeocodeWithNoResult(t *testing.T) {
 	defer ts.Close()
 
 	geocoder := bing.Geocoder(key, ts.URL+"/")
-	_, err := geocoder.ReverseGeocode(-37.81375, 164.97176)
-	assert.Equal(t, err, geo.ErrNoResult)
+	addr, err := geocoder.ReverseGeocode(-37.81375, 164.97176)
+
+	assert.NoError(t, err)
+	assert.Nil(t, addr)
 }
 
 func testServer(response string) *httptest.Server {

--- a/cached/geocoder.go
+++ b/cached/geocoder.go
@@ -18,10 +18,10 @@ func Geocoder(geocoder geo.Geocoder, cache *cache.Cache) geo.Geocoder {
 }
 
 // Geocode returns location for address
-func (c cachedGeocoder) Geocode(address string) (geo.Location, error) {
+func (c cachedGeocoder) Geocode(address string) (*geo.Location, error) {
 	// Check if we've cached this response
 	if cachedLoc, found := c.Cache.Get(address); found {
-		return cachedLoc.(geo.Location), nil
+		return cachedLoc.(*geo.Location), nil
 	}
 
 	if loc, err := c.Geocoder.Geocode(address); err != nil {
@@ -33,15 +33,15 @@ func (c cachedGeocoder) Geocode(address string) (geo.Location, error) {
 }
 
 // ReverseGeocode returns address for location
-func (c cachedGeocoder) ReverseGeocode(lat, lng float64) (string, error) {
+func (c cachedGeocoder) ReverseGeocode(lat, lng float64) (*geo.Address, error) {
 	// Check if we've cached this response
 	locKey := fmt.Sprintf("geo.Location{%f,%f}", lat, lng)
 	if cachedAddr, found := c.Cache.Get(locKey); found {
-		return cachedAddr.(string), nil
+		return cachedAddr.(*geo.Address), nil
 	}
 
 	if addr, err := c.Geocoder.ReverseGeocode(lat, lng); err != nil {
-		return "", err
+		return nil, err
 	} else {
 		c.Cache.Set(locKey, addr, 0)
 		return addr, nil

--- a/cached/geocoder_test.go
+++ b/cached/geocoder_test.go
@@ -1,15 +1,15 @@
 package cached_test
 
 import (
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/codingsince1985/geo-golang"
 	"github.com/codingsince1985/geo-golang/cached"
 	"github.com/codingsince1985/geo-golang/data"
 	"github.com/patrickmn/go-cache"
 	"github.com/stretchr/testify/assert"
-
-	"strings"
-	"testing"
-	"time"
 )
 
 var geoCache = cache.New(5*time.Minute, 30*time.Second)
@@ -17,55 +17,69 @@ var geoCache = cache.New(5*time.Minute, 30*time.Second)
 // geocoder is chained with one data geocoder with address -> location data
 // the other has location -> address data
 // this will exercise the chained fallback handling
-var geocoder = cached.Geocoder(
-	data.Geocoder(
-		data.AddressToLocation{
-			"Melbourne VIC": geo.Location{Lat: -37.814107, Lng: 144.96328},
-		},
-		data.LocationToAddress{
-			geo.Location{Lat: -37.816742, Lng: 144.964463}: "Melbourne VIC 3000, Australia",
-		},
-	),
-	geoCache,
+var (
+	addressFixture = geo.Address{
+		FormattedAddress: "64 Elizabeth Street, Melbourne, Victoria 3000, Australia",
+	}
+	locationFixture = geo.Location{
+		Lat: -37.814107,
+		Lng: 144.96328,
+	}
+	geocoder = cached.Geocoder(
+		data.Geocoder(
+			data.AddressToLocation{
+				addressFixture: locationFixture,
+			},
+			data.LocationToAddress{
+				locationFixture: addressFixture,
+			},
+		),
+		geoCache,
+	)
 )
 
 func TestGeocode(t *testing.T) {
-	location, err := geocoder.Geocode("Melbourne VIC")
+	location, err := geocoder.Geocode("64 Elizabeth Street, Melbourne, Victoria 3000, Australia")
 	assert.NoError(t, err)
-	assert.Equal(t, geo.Location{Lat: -37.814107, Lng: 144.96328}, location)
+	assert.Equal(t, locationFixture, *location)
 }
 
 func TestReverseGeocode(t *testing.T) {
-	address, err := geocoder.ReverseGeocode(-37.816742, 144.964463)
+	address, err := geocoder.ReverseGeocode(locationFixture.Lat, locationFixture.Lng)
 	assert.NoError(t, err)
-	assert.True(t, strings.HasSuffix(address, "Melbourne VIC 3000, Australia"))
+	assert.True(t, strings.HasSuffix(address.FormattedAddress, "Melbourne, Victoria 3000, Australia"))
 }
 
 func TestReverseGeocodeWithNoResult(t *testing.T) {
-	_, err := geocoder.ReverseGeocode(-37.816742, 164.964463)
-	assert.Equal(t, err, geo.ErrNoResult)
+	addr, err := geocoder.ReverseGeocode(1, 2)
+	assert.Nil(t, err)
+	assert.Nil(t, addr)
 }
 
 func TestCachedGeocode(t *testing.T) {
+	mockAddr := geo.Address{
+		FormattedAddress: "42, Some Street, Austin, Texas",
+	}
 	mock1 := data.Geocoder(
 		data.AddressToLocation{
-			"Austin,TX": geo.Location{Lat: 1, Lng: 2},
+			mockAddr: geo.Location{Lat: 1, Lng: 2},
 		},
 		data.LocationToAddress{},
 	)
 
 	c := cached.Geocoder(mock1, geoCache)
 
-	l, err := c.Geocode("Austin,TX")
+	l, err := c.Geocode("42, Some Street, Austin, Texas")
 	assert.NoError(t, err)
-	assert.Equal(t, geo.Location{Lat: 1, Lng: 2}, l)
+	assert.Equal(t, geo.Location{Lat: 1, Lng: 2}, *l)
 
 	// Should be cached
 	// TODO: write a mock Cache impl to test cache is being used
-	l, err = c.Geocode("Austin,TX")
+	l, err = c.Geocode("42, Some Street, Austin, Texas")
 	assert.NoError(t, err)
-	assert.Equal(t, geo.Location{Lat: 1, Lng: 2}, l)
+	assert.Equal(t, geo.Location{Lat: 1, Lng: 2}, *l)
 
-	_, err = c.Geocode("NOWHERE,TX")
-	assert.Equal(t, geo.ErrNoResult, err)
+	addr, err := c.Geocode("NOWHERE,TX")
+	assert.Nil(t, err)
+	assert.Nil(t, addr)
 }

--- a/chained/geocoder.go
+++ b/chained/geocoder.go
@@ -10,29 +10,29 @@ type chainedGeocoder struct{ Geocoders []geo.Geocoder }
 func Geocoder(geocoders ...geo.Geocoder) geo.Geocoder { return chainedGeocoder{Geocoders: geocoders} }
 
 // Geocode returns location for address
-func (c chainedGeocoder) Geocode(address string) (geo.Location, error) {
+func (c chainedGeocoder) Geocode(address string) (*geo.Location, error) {
 	// Geocode address by each geocoder until we get a real location response
 	for i := range c.Geocoders {
-		if l, err := c.Geocoders[i].Geocode(address); err == nil {
+		if l, err := c.Geocoders[i].Geocode(address); err == nil && l != nil {
 			return l, nil
 		}
 		// skip error and try the next geocoder
 		continue
 	}
 	// No geocoders found a result
-	return geo.Location{}, geo.ErrNoResult
+	return nil, nil
 }
 
 // ReverseGeocode returns address for location
-func (c chainedGeocoder) ReverseGeocode(lat, lng float64) (string, error) {
+func (c chainedGeocoder) ReverseGeocode(lat, lng float64) (*geo.Address, error) {
 	// Geocode address by each geocoder until we get a real location response
 	for i := range c.Geocoders {
-		if addr, err := c.Geocoders[i].ReverseGeocode(lat, lng); err == nil {
+		if addr, err := c.Geocoders[i].ReverseGeocode(lat, lng); err == nil && addr != nil {
 			return addr, nil
 		}
 		// skip error and try the next geocoder
 		continue
 	}
 	// No geocoders found a result
-	return "", geo.ErrNoResult
+	return nil, nil
 }

--- a/chained/geocoder_test.go
+++ b/chained/geocoder_test.go
@@ -13,50 +13,60 @@ import (
 // geocoder is chained with one data geocoder with address -> location data
 // the other has location -> address data
 // this will exercise the chained fallback handling
-var geocoder = chained.Geocoder(
-	data.Geocoder(
-		data.AddressToLocation{
-			"Melbourne VIC": geo.Location{Lat: -37.814107, Lng: 144.96328},
-		},
-		data.LocationToAddress{},
-	),
+var (
+	addressFixture = geo.Address{
+		FormattedAddress: "64 Elizabeth Street, Melbourne, Victoria 3000, Australia",
+	}
+	locationFixture = geo.Location{
+		Lat: -37.814107,
+		Lng: 144.96328,
+	}
+	geocoder = chained.Geocoder(
+		data.Geocoder(
+			data.AddressToLocation{
+				addressFixture: locationFixture,
+			},
+			data.LocationToAddress{},
+		),
 
-	data.Geocoder(
-		data.AddressToLocation{},
-		data.LocationToAddress{
-			geo.Location{Lat: -37.816742, Lng: 144.964463}: "Melbourne VIC 3000, Australia",
-		},
-	),
+		data.Geocoder(
+			data.AddressToLocation{},
+			data.LocationToAddress{
+				locationFixture: addressFixture,
+			},
+		),
+	)
 )
 
 func TestGeocode(t *testing.T) {
-	location, err := geocoder.Geocode("Melbourne VIC")
+	location, err := geocoder.Geocode(addressFixture.FormattedAddress)
 	assert.NoError(t, err)
-	assert.Equal(t, geo.Location{Lat: -37.814107, Lng: 144.96328}, location)
+	assert.Equal(t, geo.Location{locationFixture.Lat, locationFixture.Lng}, *location)
 }
 
 func TestReverseGeocode(t *testing.T) {
-	address, err := geocoder.ReverseGeocode(-37.816742, 144.964463)
+	address, err := geocoder.ReverseGeocode(locationFixture.Lat, locationFixture.Lng)
 	assert.NoError(t, err)
-	assert.True(t, strings.HasSuffix(address, "Melbourne VIC 3000, Australia"))
+	assert.True(t, strings.HasSuffix(address.FormattedAddress, "Melbourne, Victoria 3000, Australia"))
 }
 
 func TestReverseGeocodeWithNoResult(t *testing.T) {
-	_, err := geocoder.ReverseGeocode(-37.816742, 164.964463)
-	assert.Equal(t, err, geo.ErrNoResult)
+	addr, err := geocoder.ReverseGeocode(0, 0)
+	assert.Nil(t, err)
+	assert.Nil(t, addr)
 }
 
 func TestChainedGeocode(t *testing.T) {
 	mock1 := data.Geocoder(
 		data.AddressToLocation{
-			"Austin,TX": geo.Location{Lat: 1, Lng: 2},
+			geo.Address{FormattedAddress: "Austin,TX"}: geo.Location{Lat: 1, Lng: 2},
 		},
 		data.LocationToAddress{},
 	)
 
 	mock2 := data.Geocoder(
 		data.AddressToLocation{
-			"Dallas,TX": geo.Location{Lat: 3, Lng: 4},
+			geo.Address{FormattedAddress: "Dallas,TX"}: geo.Location{Lat: 3, Lng: 4},
 		},
 		data.LocationToAddress{},
 	)
@@ -65,12 +75,13 @@ func TestChainedGeocode(t *testing.T) {
 
 	l, err := c.Geocode("Austin,TX")
 	assert.NoError(t, err)
-	assert.Equal(t, geo.Location{Lat: 1, Lng: 2}, l)
+	assert.Equal(t, geo.Location{Lat: 1, Lng: 2}, *l)
 
 	l, err = c.Geocode("Dallas,TX")
 	assert.NoError(t, err)
-	assert.Equal(t, geo.Location{Lat: 3, Lng: 4}, l)
+	assert.Equal(t, geo.Location{Lat: 3, Lng: 4}, *l)
 
-	_, err = c.Geocode("NOWHERE,TX")
-	assert.Equal(t, geo.ErrNoResult, err)
+	addr, err := c.Geocode("NOWHERE,TX")
+	assert.Nil(t, err)
+	assert.Nil(t, addr)
 }

--- a/chained/geocoder_test.go
+++ b/chained/geocoder_test.go
@@ -1,13 +1,13 @@
 package chained_test
 
 import (
+	"strings"
+	"testing"
+
 	"github.com/codingsince1985/geo-golang"
 	"github.com/codingsince1985/geo-golang/chained"
 	"github.com/codingsince1985/geo-golang/data"
 	"github.com/stretchr/testify/assert"
-
-	"strings"
-	"testing"
 )
 
 // geocoder is chained with one data geocoder with address -> location data

--- a/data/geocoder.go
+++ b/data/geocoder.go
@@ -5,10 +5,10 @@ import (
 )
 
 // AddressToLocation maps address string to location (lat, long)
-type AddressToLocation map[string]geo.Location
+type AddressToLocation map[geo.Address]geo.Location
 
 // LocationToAddress maps location(lat,lng) to address
-type LocationToAddress map[geo.Location]string
+type LocationToAddress map[geo.Location]geo.Address
 
 // dataGeocoder represents geo data in memory
 type dataGeocoder struct {
@@ -25,17 +25,21 @@ func Geocoder(addressToLocation AddressToLocation, LocationToAddress LocationToA
 }
 
 // Geocode returns location for address
-func (d dataGeocoder) Geocode(address string) (geo.Location, error) {
-	if l, ok := d.AddressToLocation[address]; ok {
-		return l, nil
+func (d dataGeocoder) Geocode(address string) (*geo.Location, error) {
+	addr := geo.Address{
+		FormattedAddress: address,
 	}
-	return geo.Location{}, geo.ErrNoResult
+	if l, ok := d.AddressToLocation[addr]; ok {
+		return &l, nil
+	}
+
+	return nil, nil
 }
 
 // ReverseGeocode returns address for location
-func (d dataGeocoder) ReverseGeocode(lat, lng float64) (string, error) {
+func (d dataGeocoder) ReverseGeocode(lat, lng float64) (*geo.Address, error) {
 	if address, ok := d.LocationToAddress[geo.Location{Lat: lat, Lng: lng}]; ok {
-		return address, nil
+		return &address, nil
 	}
-	return "", geo.ErrNoResult
+	return nil, nil
 }

--- a/data/geocoder_test.go
+++ b/data/geocoder_test.go
@@ -1,34 +1,54 @@
 package data_test
 
 import (
+	"strings"
+	"testing"
+
 	"github.com/codingsince1985/geo-golang"
 	"github.com/codingsince1985/geo-golang/data"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
-var geocoder = data.Geocoder(
-	data.AddressToLocation{
-		"Melbourne VIC": geo.Location{Lat: -37.814107, Lng: 144.96328},
-	},
-	data.LocationToAddress{
-		geo.Location{Lat: -37.816742, Lng: 144.964463}: "Melbourne VIC 3000, Australia",
-	},
+var (
+	addressFixture = geo.Address{
+		FormattedAddress: "64 Elizabeth Street, Melbourne, Victoria 3000, Australia",
+		//Street:           "Elizabeth Street",
+		//HouseNumber:      "64",
+		//City:             "Melbourne",
+		//Postcode:         "3000",
+		//State:            "Victoria",
+		//Country:          "Australia",
+		//CountryCode:      "AU",
+	}
+	locationFixture = geo.Location{
+		Lat: -37.814107,
+		Lng: 144.96328,
+	}
+	geocoder = data.Geocoder(
+		data.AddressToLocation{
+			addressFixture: locationFixture,
+		},
+		data.LocationToAddress{
+			locationFixture: addressFixture,
+		},
+	)
 )
 
 func TestGeocode(t *testing.T) {
-	location, err := geocoder.Geocode("Melbourne VIC")
+	location, err := geocoder.Geocode(addressFixture.FormattedAddress)
 	assert.NoError(t, err)
-	assert.Equal(t, geo.Location{Lat: -37.814107, Lng: 144.96328}, location)
+	assert.Equal(t, geo.Location{Lat: -37.814107, Lng: 144.96328}, *location)
 }
 
 func TestReverseGeocode(t *testing.T) {
-	address, err := geocoder.ReverseGeocode(-37.816742, 144.964463)
-	assert.NoError(t, err)
-	assert.Equal(t, "Melbourne VIC 3000, Australia", address)
+	address, err := geocoder.ReverseGeocode(locationFixture.Lat, locationFixture.Lng)
+	assert.Nil(t, err)
+	assert.NotNil(t, address)
+	assert.True(t, strings.Contains(address.FormattedAddress, "Melbourne, Victoria 3000, Australia"))
 }
 
 func TestReverseGeocodeWithNoResult(t *testing.T) {
-	_, err := geocoder.ReverseGeocode(-37.816742, 164.964463)
-	assert.Equal(t, err, geo.ErrNoResult)
+	addr, err := geocoder.ReverseGeocode(1, 2)
+	assert.Nil(t, err)
+	assert.Nil(t, addr)
 }

--- a/data/geocoder_test.go
+++ b/data/geocoder_test.go
@@ -12,13 +12,6 @@ import (
 var (
 	addressFixture = geo.Address{
 		FormattedAddress: "64 Elizabeth Street, Melbourne, Victoria 3000, Australia",
-		//Street:           "Elizabeth Street",
-		//HouseNumber:      "64",
-		//City:             "Melbourne",
-		//Postcode:         "3000",
-		//State:            "Victoria",
-		//Country:          "Australia",
-		//CountryCode:      "AU",
 	}
 	locationFixture = geo.Location{
 		Lat: -37.814107,

--- a/examples/geocoder_example.go
+++ b/examples/geocoder_example.go
@@ -146,5 +146,5 @@ func try(geocoder geo.Geocoder) {
 	} else {
 		fmt.Println("got <nil> address")
 	}
-	fmt.Println("\n")
+	fmt.Print("\n")
 }

--- a/examples/geocoder_example.go
+++ b/examples/geocoder_example.go
@@ -63,44 +63,73 @@ func ExampleGeocoder() {
 		google.Geocoder(os.Getenv("GOOGLE_API_KEY")),
 	))
 	// Output: Google Geocoding API
-	// Melbourne VIC location is (-37.813628, 144.963058)
-	// Address of (-37.813611,144.963056) is 350 Bourke St, Melbourne VIC 3004, Australia
+	// Melbourne VIC location is (-37.813611, 144.963056)
+	// Address of (-37.813611,144.963056) is 197 Elizabeth St, Melbourne VIC 3000, Australia
+	// Detailed address: &geo.Address{FormattedAddress:"197 Elizabeth St, Melbourne VIC 3000, Australia",
+	// 	Street:"Elizabeth Street", HouseNumber:"197", Suburb:"", Postcode:"3000", State:"Victoria",
+	// 	StateDistrict:"Melbourne City", County:"", Country:"Australia", CountryCode:"AU", City:"Melbourne"}
 	//
 	// Mapquest Nominatim
 	// Melbourne VIC location is (-37.814218, 144.963161)
 	// Address of (-37.813611,144.963056) is Melbourne's GPO, Postal Lane, Melbourne, City of Melbourne, Greater Melbourne, Victoria, 3000, Australia
+	// Detailed address: &geo.Address{FormattedAddress:"Melbourne's GPO, Postal Lane, Melbourne, City of Melbourne,
+	// 	Greater Melbourne, Victoria, 3000, Australia", Street:"Postal Lane", HouseNumber:"", Suburb:"Melbourne",
+	// 	Postcode:"3000", State:"Victoria", StateDistrict:"", County:"City of Melbourne", Country:"Australia", CountryCode:"AU", City:"Melbourne"}
 	//
 	// Mapquest Open streetmaps
 	// Melbourne VIC location is (-37.814218, 144.963161)
 	// Address of (-37.813611,144.963056) is Elizabeth Street, Melbourne, Victoria, AU
+	// Detailed address: &geo.Address{FormattedAddress:"Elizabeth Street, 3000, Melbourne, Victoria, AU",
+	// 	Street:"Elizabeth Street", HouseNumber:"", Suburb:"", Postcode:"3000", State:"Victoria", StateDistrict:"",
+	// 	County:"", Country:"", CountryCode:"AU", City:"Melbourne"}
 	//
 	// OpenCage Data
 	// Melbourne VIC location is (-37.814217, 144.963161)
 	// Address of (-37.813611,144.963056) is Melbourne's GPO, Postal Lane, Melbourne VIC 3000, Australia
+	// Detailed address: &geo.Address{FormattedAddress:"Melbourne's GPO, Postal Lane, Melbourne VIC 3000, Australia",
+	// 	Street:"Postal Lane", HouseNumber:"", Suburb:"Melbourne (3000)", Postcode:"3000", State:"Victoria",
+	// 	StateDistrict:"", County:"City of Melbourne", Country:"Australia", CountryCode:"AU", City:"Melbourne"}
 	//
 	// HERE API
 	// Melbourne VIC location is (-37.817530, 144.967150)
 	// Address of (-37.813611,144.963056) is 197 Elizabeth St, Melbourne VIC 3000, Australia
+	// Detailed address: &geo.Address{FormattedAddress:"197 Elizabeth St, Melbourne VIC 3000, Australia", Street:"Elizabeth St",
+	// 	HouseNumber:"197", Suburb:"", Postcode:"3000", State:"Victoria", StateDistrict:"", County:"", Country:"Australia",
+	// 	CountryCode:"AUS", City:"Melbourne"}
 	//
 	// Bing Geocoding API
 	// Melbourne VIC location is (-37.824299, 144.977997)
 	// Address of (-37.813611,144.963056) is Elizabeth St, Melbourne, VIC 3000
+	// Detailed address: &geo.Address{FormattedAddress:"Elizabeth St, Melbourne, VIC 3000", Street:"Elizabeth St",
+	// 	HouseNumber:"", Suburb:"", Postcode:"3000", State:"", StateDistrict:"", County:"", Country:"Australia", CountryCode:"", City:"Melbourne"}
 	//
 	// Mapbox API
 	// Melbourne VIC location is (-37.814200, 144.963200)
 	// Address of (-37.813611,144.963056) is Elwood Park Playground, Melbourne, Victoria 3000, Australia
+	// Detailed address: &geo.Address{FormattedAddress:"Elwood Park Playground, Melbourne, Victoria 3000, Australia",
+	// 	Street:"Elwood Park Playground", HouseNumber:"", Suburb:"", Postcode:"3000", State:"Victoria", StateDistrict:"",
+	// 	County:"", Country:"Australia", CountryCode:"AU", City:"Melbourne"}
 	//
 	// OpenStreetMap
 	// Melbourne VIC location is (-37.814217, 144.963161)
 	// Address of (-37.813611,144.963056) is Melbourne's GPO, Postal Lane, Chinatown, Melbourne, City of Melbourne, Greater Melbourne, Victoria, 3000, Australia
+	// Detailed address: &geo.Address{FormattedAddress:"Melbourne's GPO, Postal Lane, Chinatown, Melbourne, City of Melbourne, Greater Melbourne,
+	// 	Victoria, 3000, Australia", Street:"Postal Lane", HouseNumber:"", Suburb:"Melbourne", Postcode:"3000", State:"Victoria",
+	// 	StateDistrict:"", County:"", Country:"Australia", CountryCode:"AU", City:"Melbourne"}
 	//
 	// LocationIQ
 	// Melbourne VIC location is (-37.814217, 144.963161)
 	// Address of (-37.813611,144.963056) is Melbourne's GPO, Postal Lane, Chinatown, Melbourne, City of Melbourne, Greater Melbourne, Victoria, 3000, Australia
+	// Detailed address: &geo.Address{FormattedAddress:"Melbourne's GPO, Postal Lane, Chinatown, Melbourne, City of Melbourne, Greater Melbourne,
+	// 	Victoria, 3000, Australia", Street:"Postal Lane", HouseNumber:"", Suburb:"Melbourne", Postcode:"3000", State:"Victoria",
+	// 	StateDistrict:"", County:"", Country:"Australia", CountryCode:"AU", City:"Melbourne"}
 	//
 	// ChainedAPI[OpenStreetmap -> Google]
 	// Melbourne VIC location is (-37.814217, 144.963161)
 	// Address of (-37.813611,144.963056) is Melbourne's GPO, Postal Lane, Chinatown, Melbourne, City of Melbourne, Greater Melbourne, Victoria, 3000, Australia
+	// Detailed address: &geo.Address{FormattedAddress:"Melbourne's GPO, Postal Lane, Chinatown, Melbourne, City of Melbourne, Greater Melbourne,
+	// 	Victoria, 3000, Australia", Street:"Postal Lane", HouseNumber:"", Suburb:"Melbourne", Postcode:"3000", State:"Victoria",
+	// 	StateDistrict:"", County:"", Country:"Australia", CountryCode:"AU", City:"Melbourne"}
 }
 
 func try(geocoder geo.Geocoder) {

--- a/examples/geocoder_example.go
+++ b/examples/geocoder_example.go
@@ -1,4 +1,4 @@
-package geo_test
+package main
 
 import (
 	"fmt"
@@ -24,12 +24,16 @@ const (
 	ZOOM     = 18
 )
 
+func main() {
+	ExampleGeocoder()
+}
+
 func ExampleGeocoder() {
 	fmt.Println("Google Geocoding API")
 	try(google.Geocoder(os.Getenv("GOOGLE_API_KEY")))
 
 	fmt.Println("Mapquest Nominatim")
-	try(nominatim.Geocoder(os.Getenv("MAPQUEST_NOMINATUM_KEY")))
+	try(nominatim.Geocoder(os.Getenv("MAPQUEST_NOMINATIM_KEY")))
 
 	fmt.Println("Mapquest Open streetmaps")
 	try(open.Geocoder(os.Getenv("MAPQUEST_OPEN_KEY")))

--- a/geocoder.go
+++ b/geocoder.go
@@ -6,3 +6,24 @@ type Geocoder interface {
 	Geocode(address string) (*Location, error)
 	ReverseGeocode(lat, lng float64) (*Address, error)
 }
+
+// Location is the output of Geocode
+type Location struct {
+	Lat, Lng float64
+}
+
+// Address is returned by ReverseGeocode.
+// This is a structured representation of an address, including its flat representation
+type Address struct {
+	FormattedAddress string
+	Street           string
+	HouseNumber      string
+	Suburb           string
+	Postcode         string
+	State            string
+	StateDistrict    string
+	County           string
+	Country          string
+	CountryCode      string
+	City             string
+}

--- a/geocoder.go
+++ b/geocoder.go
@@ -3,6 +3,6 @@ package geo
 
 // Geocoder can look up (lat, long) by address and address by (lat, long)
 type Geocoder interface {
-	Geocode(address string) (Location, error)
-	ReverseGeocode(lat, lng float64) (Address, error)
+	Geocode(address string) (*Location, error)
+	ReverseGeocode(lat, lng float64) (*Address, error)
 }

--- a/geocoder.go
+++ b/geocoder.go
@@ -4,5 +4,5 @@ package geo
 // Geocoder can look up (lat, long) by address and address by (lat, long)
 type Geocoder interface {
 	Geocode(address string) (Location, error)
-	ReverseGeocode(lat, lng float64) (string, error)
+	ReverseGeocode(lat, lng float64) (Address, error)
 }

--- a/geocoder_test.go
+++ b/geocoder_test.go
@@ -101,7 +101,17 @@ func ExampleGeocoder() {
 
 func try(geocoder geo.Geocoder) {
 	location, _ := geocoder.Geocode(addr)
-	fmt.Printf("%s location is (%.6f, %.6f)\n", addr, location.Lat, location.Lng)
+	if location != nil {
+		fmt.Printf("%s location is (%.6f, %.6f)\n", addr, location.Lat, location.Lng)
+	} else {
+		fmt.Println("got <nil> location")
+	}
 	address, _ := geocoder.ReverseGeocode(lat, lng)
-	fmt.Printf("Address of (%.6f,%.6f) is %s\n\n", lat, lng, address)
+	if address != nil {
+		fmt.Printf("Address of (%.6f,%.6f) is %s\n", lat, lng, address.FormattedAddress)
+		fmt.Printf("Detailed address: %#v\n", address)
+	} else {
+		fmt.Println("got <nil> address")
+	}
+	fmt.Println("\n")
 }

--- a/google/geocoder.go
+++ b/google/geocoder.go
@@ -5,7 +5,7 @@ package google
 import (
 	"fmt"
 
-	geo "github.com/codingsince1985/geo-golang"
+	"github.com/codingsince1985/geo-golang"
 )
 
 type (

--- a/google/geocoder.go
+++ b/google/geocoder.go
@@ -11,12 +11,32 @@ type (
 	baseURL         string
 	geocodeResponse struct {
 		Results []struct {
-			FormattedAddress string `json:"formatted_address"`
-			Geometry         struct {
+			FormattedAddress  string                   `json:"formatted_address"`
+			AddressComponents []googleAddressComponent `json:"address_components"`
+			Geometry          struct {
 				Location geo.Location
 			}
 		}
+		Status string `json: "status"`
 	}
+	googleAddressComponent struct {
+		LongName  string   `json:"long_name"`
+		ShortName string   `json:"short_name"`
+		Types     []string `json:"types"`
+	}
+)
+
+const (
+	statusOK                   = "OK"
+	statusNoResults            = "ZERO_RESULTS"
+	componentTypeHouseNumber   = "street_number"
+	componentTypeStreetName    = "route"
+	componentTypeSuburb        = "sublocality"
+	componentTypeLocality      = "locality"
+	componentTypeStateDistrict = "administrative_area_level_2"
+	componentTypeState         = "administrative_area_level_1"
+	componentTypeCountry       = "country"
+	componentTypePostcode      = "postal_code"
 )
 
 // Geocoder constructs Google geocoder
@@ -37,19 +57,71 @@ func getUrl(apiKey string, baseURLs ...string) string {
 func (b baseURL) GeocodeURL(address string) string { return string(b) + "address=" + address }
 
 func (b baseURL) ReverseGeocodeURL(l geo.Location) string {
-	return string(b) + fmt.Sprintf("latlng=%f,%f", l.Lat, l.Lng)
+	return string(b) + fmt.Sprintf("result_type=street_address&latlng=%f,%f", l.Lat, l.Lng)
 }
 
-func (r *geocodeResponse) Location() geo.Location {
-	if len(r.Results) > 0 {
-		return r.Results[0].Geometry.Location
+func (r *geocodeResponse) Location() (*geo.Location, error) {
+	if r.Status == statusNoResults {
+		return nil, nil
+	} else if r.Status != statusOK {
+		return nil, fmt.Errorf("geocoding error: %s", r.Status)
 	}
-	return geo.Location{}
+
+	return &r.Results[0].Geometry.Location, nil
 }
 
-func (r *geocodeResponse) Address() string {
-	if len(r.Results) > 0 {
-		return r.Results[0].FormattedAddress
+func (r *geocodeResponse) Address() (*geo.Address, error) {
+	if r.Status == statusNoResults {
+		return nil, nil
+	} else if r.Status != statusOK {
+		return nil, fmt.Errorf("reverse geocoding error: %s", r.Status)
 	}
-	return ""
+
+	if len(r.Results) == 0 || len(r.Results[0].AddressComponents) == 0 {
+		return nil, nil
+	}
+
+	addr := parseGoogleResult(r)
+
+	return addr, nil
+}
+
+func parseGoogleResult(r *geocodeResponse) *geo.Address {
+	addr := &geo.Address{}
+	res := r.Results[0]
+	addr.FormattedAddress = res.FormattedAddress
+OuterLoop:
+	for _, comp := range res.AddressComponents {
+		for _, typ := range comp.Types {
+			switch typ {
+			case componentTypeHouseNumber:
+				addr.HouseNumber = comp.LongName
+				continue OuterLoop
+			case componentTypeStreetName:
+				addr.Street = comp.LongName
+				continue OuterLoop
+			case componentTypeSuburb:
+				addr.Suburb = comp.LongName
+				continue OuterLoop
+			case componentTypeLocality:
+				addr.City = comp.LongName
+				continue OuterLoop
+			case componentTypeStateDistrict:
+				addr.StateDistrict = comp.LongName
+				continue OuterLoop
+			case componentTypeState:
+				addr.State = comp.LongName
+				continue OuterLoop
+			case componentTypeCountry:
+				addr.Country = comp.LongName
+				addr.CountryCode = comp.ShortName
+				continue OuterLoop
+			case componentTypePostcode:
+				addr.Postcode = comp.LongName
+				continue OuterLoop
+			}
+		}
+	}
+
+	return addr
 }

--- a/google/geocoder.go
+++ b/google/geocoder.go
@@ -4,6 +4,7 @@ package google
 
 import (
 	"fmt"
+
 	geo "github.com/codingsince1985/geo-golang"
 )
 

--- a/google/geocoder_test.go
+++ b/google/geocoder_test.go
@@ -1,14 +1,15 @@
 package google_test
 
 import (
-	"github.com/codingsince1985/geo-golang"
-	"github.com/codingsince1985/geo-golang/google"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/codingsince1985/geo-golang"
+	"github.com/codingsince1985/geo-golang/google"
+	"github.com/stretchr/testify/assert"
 )
 
 var token = os.Getenv("GOOGLE_API_KEY")

--- a/google/geocoder_test.go
+++ b/google/geocoder_test.go
@@ -20,7 +20,7 @@ func TestGeocode(t *testing.T) {
 	geocoder := google.Geocoder(token, ts.URL+"/")
 	location, err := geocoder.Geocode("60 Collins St, Melbourne VIC 3000")
 	assert.NoError(t, err)
-	assert.Equal(t, geo.Location{Lat: -37.8137683, Lng: 144.9718448}, location)
+	assert.Equal(t, geo.Location{Lat: -37.8137683, Lng: 144.9718448}, *location)
 }
 
 func TestReverseGeocode(t *testing.T) {
@@ -30,7 +30,8 @@ func TestReverseGeocode(t *testing.T) {
 	geocoder := google.Geocoder(token, ts.URL+"/")
 	address, err := geocoder.ReverseGeocode(-37.8137683, 144.9718448)
 	assert.NoError(t, err)
-	assert.True(t, strings.HasPrefix(address, "60 Collins St"))
+	assert.True(t, strings.HasPrefix(address.FormattedAddress, "60 Collins St"))
+	assert.True(t, strings.HasPrefix(address.Street, "Collins St"))
 }
 
 func TestReverseGeocodeWithNoResult(t *testing.T) {
@@ -38,8 +39,9 @@ func TestReverseGeocodeWithNoResult(t *testing.T) {
 	defer ts.Close()
 
 	geocoder := google.Geocoder(token, ts.URL+"/")
-	_, err := geocoder.ReverseGeocode(-37.8137683, 164.9718448)
-	assert.Equal(t, err, geo.ErrNoResult)
+	addr, err := geocoder.ReverseGeocode(-37.8137683, 164.9718448)
+	assert.Nil(t, err)
+	assert.Nil(t, addr)
 }
 
 func testServer(response string) *httptest.Server {

--- a/here/geocoder.go
+++ b/here/geocoder.go
@@ -3,6 +3,7 @@ package here
 
 import (
 	"fmt"
+
 	"github.com/codingsince1985/geo-golang"
 )
 

--- a/here/geocoder.go
+++ b/here/geocoder.go
@@ -85,7 +85,10 @@ func (r *geocodeResponse) Location() (*geo.Location, error) {
 		return nil, nil
 	}
 	p := r.Response.View[0].Result[0].Location.DisplayPosition
-	return &geo.Location{p.Latitude, p.Longitude}, nil
+	return &geo.Location{
+		Lat: p.Latitude,
+		Lng: p.Longitude,
+	}, nil
 }
 
 func (r *geocodeResponse) Address() (*geo.Address, error) {

--- a/here/geocoder_test.go
+++ b/here/geocoder_test.go
@@ -1,14 +1,15 @@
 package here_test
 
 import (
-	"github.com/codingsince1985/geo-golang"
-	"github.com/codingsince1985/geo-golang/here"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/codingsince1985/geo-golang"
+	"github.com/codingsince1985/geo-golang/here"
+	"github.com/stretchr/testify/assert"
 )
 
 var appID = os.Getenv("HERE_APP_ID")

--- a/here/geocoder_test.go
+++ b/here/geocoder_test.go
@@ -21,7 +21,7 @@ func TestGeocode(t *testing.T) {
 	geocoder := here.Geocoder(appID, appCode, 100, ts.URL+"/")
 	location, err := geocoder.Geocode("60 Collins St, Melbourne VIC 3000")
 	assert.NoError(t, err)
-	assert.Equal(t, geo.Location{Lat: -37.81375, Lng: 144.97176}, location)
+	assert.Equal(t, geo.Location{Lat: -37.81375, Lng: 144.97176}, *location)
 }
 
 func TestReverseGeocode(t *testing.T) {
@@ -31,7 +31,7 @@ func TestReverseGeocode(t *testing.T) {
 	geocoder := here.Geocoder(appID, appCode, 100, ts.URL+"/")
 	address, err := geocoder.ReverseGeocode(-37.81375, 144.97176)
 	assert.NoError(t, err)
-	assert.True(t, strings.HasPrefix(address, "56-64 Collins St"))
+	assert.True(t, strings.HasPrefix(address.FormattedAddress, "56-64 Collins St"))
 }
 
 func TestReverseGeocodeWithNoResult(t *testing.T) {
@@ -39,8 +39,8 @@ func TestReverseGeocodeWithNoResult(t *testing.T) {
 	defer ts.Close()
 
 	geocoder := here.Geocoder(appID, appCode, 100, ts.URL+"/")
-	_, err := geocoder.ReverseGeocode(-37.81375, 164.97176)
-	assert.Equal(t, err, geo.ErrNoResult)
+	addr, _ := geocoder.ReverseGeocode(-37.81375, 164.97176)
+	assert.Nil(t, addr)
 }
 
 func testServer(response string) *httptest.Server {

--- a/http_geocoder.go
+++ b/http_geocoder.go
@@ -159,7 +159,11 @@ func response(ctx context.Context, url string, obj ResponseParser) error {
 		return err
 	}
 
-	if err := json.Unmarshal([]byte(strings.Trim(string(data), " []")), obj); err != nil {
+	body := strings.Trim(string(data), " []")
+	if body == "" {
+		return nil
+	}
+	if err := json.Unmarshal([]byte(body), obj); err != nil {
 		return err
 	}
 

--- a/http_geocoder.go
+++ b/http_geocoder.go
@@ -54,11 +54,6 @@ type ResponseParser interface {
 	Address() (*Address, error)
 }
 
-// AddressFormatter returns the flat uniform representation of the address (varies based on service provider)
-type AddressFormatter interface {
-	FormattedAddress() string
-}
-
 // HTTPGeocoder has EndpointBuilder and ResponseParser
 type HTTPGeocoder struct {
 	EndpointBuilder

--- a/http_geocoder.go
+++ b/http_geocoder.go
@@ -24,6 +24,21 @@ type Location struct {
 	Lat, Lng float64
 }
 
+// Address is the structured representation of an address, including its flat representation
+type Address struct {
+	FormattedAddress string
+	Street           string
+	HouseNumber      string
+	Suburb           string
+	Postcode         string
+	State            string
+	StateDistrict    string
+	County           string
+	Country          string
+	CountryCode      string
+	City             string
+}
+
 // EndpointBuilder defines functions that build urls for geocode/reverse geocode
 type EndpointBuilder interface {
 	GeocodeURL(string) string
@@ -36,7 +51,12 @@ type ResponseParserFactory func() ResponseParser
 // ResponseParser defines functions that parse response of geocode/reverse geocode
 type ResponseParser interface {
 	Location() Location
-	Address() string
+	Address() Address
+}
+
+// AddressFormatter returns the flat uniform representation of the address (varies based on service provider)
+type AddressFormatter interface {
+	FormattedAddress() string
 }
 
 // HTTPGeocoder has EndpointBuilder and ResponseParser

--- a/http_geocoder.go
+++ b/http_geocoder.go
@@ -15,32 +15,8 @@ import (
 // Default timeout for the request execution
 const DefaultTimeout = time.Second * 8
 
-// ErrNoResult occurs when no result returned
-var ErrNoResult = errors.New("NO_RESULT")
-
 // ErrTimeout occurs when no response returned within timeoutInSeconds
 var ErrTimeout = errors.New("TIMEOUT")
-
-// Location is the output of Geocode
-type Location struct {
-	Lat, Lng float64
-}
-
-// Address is returned by ReverseGeocode.
-// This is a structured representation of an address, including its flat representation
-type Address struct {
-	FormattedAddress string
-	Street           string
-	HouseNumber      string
-	Suburb           string
-	Postcode         string
-	State            string
-	StateDistrict    string
-	County           string
-	Country          string
-	CountryCode      string
-	City             string
-}
 
 // EndpointBuilder defines functions that build urls for geocode/reverse geocode
 type EndpointBuilder interface {

--- a/http_geocoder.go
+++ b/http_geocoder.go
@@ -83,8 +83,8 @@ func (g HTTPGeocoder) Geocode(address string) (Location, error) {
 }
 
 // ReverseGeocode returns address for location
-func (g HTTPGeocoder) ReverseGeocode(lat, lng float64) (string, error) {
-	ch := make(chan string, 1)
+func (g HTTPGeocoder) ReverseGeocode(lat, lng float64) (Address, error) {
+	ch := make(chan Address, 1)
 	go func() {
 		responseParser := g.ResponseParserFactory()
 		response(g.ReverseGeocodeURL(Location{lat, lng}), responseParser)
@@ -95,7 +95,7 @@ func (g HTTPGeocoder) ReverseGeocode(lat, lng float64) (string, error) {
 	case address := <-ch:
 		return address, anyError(address)
 	case <-time.After(timeout):
-		return "", ErrTimeout
+		return Address{}, ErrTimeout
 	}
 }
 
@@ -123,6 +123,10 @@ func anyError(v interface{}) error {
 		}
 	case string:
 		if v == "" {
+			return ErrNoResult
+		}
+	case Address:
+		if v.Postcode == "" {
 			return ErrNoResult
 		}
 	}

--- a/locationiq/geocoder.go
+++ b/locationiq/geocoder.go
@@ -90,7 +90,7 @@ func (r *geocodeResponse) Address() geo.Address {
 		HouseNumber:      r.Addr.HouseNumber,
 		City:             r.Addr.City,
 		Postcode:         r.Addr.Postcode,
-		Country:          r.Addr.CountryCode,
+		Country:          r.Addr.Country,
 		CountryCode:      r.Addr.CountryCode,
 	}
 }

--- a/locationiq/geocoder.go
+++ b/locationiq/geocoder.go
@@ -93,10 +93,3 @@ func (r *geocodeResponse) Address() (*geo.Address, error) {
 		CountryCode:      strings.ToUpper(r.Addr.CountryCode),
 	}, nil
 }
-
-func (r *geocodeResponse) FormattedAddress() string {
-	if r.Error != "" {
-		return ""
-	}
-	return r.DisplayName
-}

--- a/locationiq/geocoder.go
+++ b/locationiq/geocoder.go
@@ -70,21 +70,40 @@ func (b baseURL) ReverseGeocodeURL(l geo.Location) string {
 	return string(b) + "reverse.php?key=" + key + fmt.Sprintf("&format=json&lat=%f&lon=%f&zoom=%d", l.Lat, l.Lng, zoom)
 }
 
+<<<<<<< HEAD
 func (r *geocodeResponse) Location() geo.Location {
 	l := geo.Location{}
 	// In case of empty response from LocationIQ or any other error we get zero values
 	if r.Lat != "" && r.Lon != "" {
 		l.Lat = geo.ParseFloat(r.Lat)
 		l.Lng = geo.ParseFloat(r.Lon)
+=======
+func (r *geocodeResponse) Location() (*geo.Location, error) {
+	if r.Lat == "" || r.Lon == "" {
+		return nil, fmt.Errorf("empty lat/lon value: %s", r.Error)
+>>>>>>> Return pointer instead of value; also return error
 	}
-	return l
+
+	lat, err := parseFloat(r.Lat)
+	if err != nil {
+		return nil, fmt.Errorf("error converting lat to float: %s", err)
+	}
+	lon, err := parseFloat(r.Lon)
+	if err != nil {
+		return nil, fmt.Errorf("error converting lon to float: %s", err)
+	}
+
+	return &geo.Location{
+		Lat: lat,
+		Lng: lon,
+	}, nil
 }
 
-func (r *geocodeResponse) Address() geo.Address {
+func (r *geocodeResponse) Address() (*geo.Address, error) {
 	if r.Error != "" {
-		return geo.Address{}
+		return nil, fmt.Errorf("error reverse geocoding: %s", r.Error)
 	}
-	return geo.Address{
+	return &geo.Address{
 		FormattedAddress: r.DisplayName,
 		Street:           r.Addr.Road,
 		HouseNumber:      r.Addr.HouseNumber,
@@ -92,7 +111,7 @@ func (r *geocodeResponse) Address() geo.Address {
 		Postcode:         r.Addr.Postcode,
 		Country:          r.Addr.Country,
 		CountryCode:      r.Addr.CountryCode,
-	}
+	}, nil
 }
 
 func (r *geocodeResponse) FormattedAddress() string {
@@ -101,3 +120,10 @@ func (r *geocodeResponse) FormattedAddress() string {
 	}
 	return r.DisplayName
 }
+<<<<<<< HEAD
+=======
+
+func parseFloat(value string) (float64, error) {
+	return strconv.ParseFloat(value, 64)
+}
+>>>>>>> Return pointer instead of value; also return error

--- a/locationiq/geocoder.go
+++ b/locationiq/geocoder.go
@@ -80,7 +80,22 @@ func (r *geocodeResponse) Location() geo.Location {
 	return l
 }
 
-func (r *geocodeResponse) Address() string {
+func (r *geocodeResponse) Address() geo.Address {
+	if r.Error != "" {
+		return geo.Address{}
+	}
+	return geo.Address{
+		FormattedAddress: r.DisplayName,
+		Street:           r.Addr.Road,
+		HouseNumber:      r.Addr.HouseNumber,
+		City:             r.Addr.City,
+		Postcode:         r.Addr.Postcode,
+		Country:          r.Addr.CountryCode,
+		CountryCode:      r.Addr.CountryCode,
+	}
+}
+
+func (r *geocodeResponse) FormattedAddress() string {
 	if r.Error != "" {
 		return ""
 	}

--- a/locationiq/geocoder.go
+++ b/locationiq/geocoder.go
@@ -4,6 +4,7 @@ package locationiq
 import (
 	"fmt"
 	"github.com/codingsince1985/geo-golang"
+	"strings"
 )
 
 type baseURL string
@@ -19,6 +20,7 @@ type locationiqAddress struct {
 	Suburb        string `json:"suburb"`
 	City          string `json:"city"`
 	County        string `json:"county"`
+	Village       string `json:"village"`
 	Country       string `json:"country"`
 	CountryCode   string `json:"country_code"`
 	Road          string `json:"road"`
@@ -103,14 +105,22 @@ func (r *geocodeResponse) Address() (*geo.Address, error) {
 	if r.Error != "" {
 		return nil, fmt.Errorf("error reverse geocoding: %s", r.Error)
 	}
+	var locality string
+	if r.Addr.City != "" {
+		locality = r.Addr.City
+	} else {
+		locality = r.Addr.Village
+	}
 	return &geo.Address{
 		FormattedAddress: r.DisplayName,
 		Street:           r.Addr.Road,
 		HouseNumber:      r.Addr.HouseNumber,
-		City:             r.Addr.City,
+		City:             locality,
 		Postcode:         r.Addr.Postcode,
+		Suburb:           r.Addr.Suburb,
+		State:            r.Addr.State,
 		Country:          r.Addr.Country,
-		CountryCode:      r.Addr.CountryCode,
+		CountryCode:      strings.ToUpper(r.Addr.CountryCode),
 	}, nil
 }
 

--- a/locationiq/geocoder.go
+++ b/locationiq/geocoder.go
@@ -75,6 +75,9 @@ func (b baseURL) ReverseGeocodeURL(l geo.Location) string {
 }
 
 func (r *geocodeResponse) Location() (*geo.Location, error) {
+	if r.Error != "" {
+		return nil, fmt.Errorf("geocoding error: %s", r.Error)
+	}
 	if r.Lat == "" || r.Lon == "" {
 		return nil, fmt.Errorf("empty lat/lon value: %s", r.Error)
 	}
@@ -87,7 +90,7 @@ func (r *geocodeResponse) Location() (*geo.Location, error) {
 
 func (r *geocodeResponse) Address() (*geo.Address, error) {
 	if r.Error != "" {
-		return nil, fmt.Errorf("error reverse geocoding: %s", r.Error)
+		return nil, fmt.Errorf("reverse geocoding error: %s", r.Error)
 	}
 	var locality string
 	if r.Addr.City != "" {

--- a/locationiq/geocoder.go
+++ b/locationiq/geocoder.go
@@ -19,13 +19,18 @@ type geocodeResponse struct {
 
 type locationiqAddress struct {
 	HouseNumber   string `json:"house_number"`
+	Road          string `json:"road"`
+	Pedestrian    string `json:"pedestrian"`
+	Cycleway      string `json:"cycleway"`
+	Highway       string `json:"highway"`
+	Path          string `json:"path"`
 	Suburb        string `json:"suburb"`
 	City          string `json:"city"`
-	County        string `json:"county"`
+	Town          string `json:"town"`
 	Village       string `json:"village"`
+	County        string `json:"county"`
 	Country       string `json:"country"`
 	CountryCode   string `json:"country_code"`
-	Road          string `json:"road"`
 	State         string `json:"state"`
 	StateDistrict string `json:"state_district"`
 	Postcode      string `json:"postcode"`
@@ -92,17 +97,12 @@ func (r *geocodeResponse) Address() (*geo.Address, error) {
 	if r.Error != "" {
 		return nil, fmt.Errorf("reverse geocoding error: %s", r.Error)
 	}
-	var locality string
-	if r.Addr.City != "" {
-		locality = r.Addr.City
-	} else {
-		locality = r.Addr.Village
-	}
+
 	return &geo.Address{
 		FormattedAddress: r.DisplayName,
-		Street:           r.Addr.Road,
+		Street:           extractStreet(r.Addr),
 		HouseNumber:      r.Addr.HouseNumber,
-		City:             locality,
+		City:             extractLocality(r.Addr),
 		Postcode:         r.Addr.Postcode,
 		Suburb:           r.Addr.Suburb,
 		State:            r.Addr.State,
@@ -116,4 +116,36 @@ func (r *geocodeResponse) FormattedAddress() string {
 		return ""
 	}
 	return r.DisplayName
+}
+
+func extractLocality(a locationiqAddress) string {
+	var locality string
+
+	if a.City != "" {
+		locality = a.City
+	} else if a.Town != "" {
+		locality = a.Town
+	} else if a.Village != "" {
+		locality = a.Village
+	}
+
+	return locality
+}
+
+func extractStreet(a locationiqAddress) string {
+	var street string
+
+	if a.Road != "" {
+		street = a.Road
+	} else if a.Pedestrian != "" {
+		street = a.Pedestrian
+	} else if a.Path != "" {
+		street = a.Path
+	} else if a.Cycleway != "" {
+		street = a.Cycleway
+	} else if a.Highway != "" {
+		street = a.Highway
+	}
+
+	return street
 }

--- a/locationiq/geocoder.go
+++ b/locationiq/geocoder.go
@@ -3,8 +3,10 @@ package locationiq
 
 import (
 	"fmt"
-	"github.com/codingsince1985/geo-golang"
+	"strconv"
 	"strings"
+
+	"github.com/codingsince1985/geo-golang"
 )
 
 type baseURL string
@@ -72,32 +74,14 @@ func (b baseURL) ReverseGeocodeURL(l geo.Location) string {
 	return string(b) + "reverse.php?key=" + key + fmt.Sprintf("&format=json&lat=%f&lon=%f&zoom=%d", l.Lat, l.Lng, zoom)
 }
 
-<<<<<<< HEAD
-func (r *geocodeResponse) Location() geo.Location {
-	l := geo.Location{}
-	// In case of empty response from LocationIQ or any other error we get zero values
-	if r.Lat != "" && r.Lon != "" {
-		l.Lat = geo.ParseFloat(r.Lat)
-		l.Lng = geo.ParseFloat(r.Lon)
-=======
 func (r *geocodeResponse) Location() (*geo.Location, error) {
 	if r.Lat == "" || r.Lon == "" {
 		return nil, fmt.Errorf("empty lat/lon value: %s", r.Error)
->>>>>>> Return pointer instead of value; also return error
-	}
-
-	lat, err := parseFloat(r.Lat)
-	if err != nil {
-		return nil, fmt.Errorf("error converting lat to float: %s", err)
-	}
-	lon, err := parseFloat(r.Lon)
-	if err != nil {
-		return nil, fmt.Errorf("error converting lon to float: %s", err)
 	}
 
 	return &geo.Location{
-		Lat: lat,
-		Lng: lon,
+		Lat: geo.ParseFloat(r.Lat),
+		Lng: geo.ParseFloat(r.Lon),
 	}, nil
 }
 
@@ -130,10 +114,3 @@ func (r *geocodeResponse) FormattedAddress() string {
 	}
 	return r.DisplayName
 }
-<<<<<<< HEAD
-=======
-
-func parseFloat(value string) (float64, error) {
-	return strconv.ParseFloat(value, 64)
-}
->>>>>>> Return pointer instead of value; also return error

--- a/locationiq/geocoder_test.go
+++ b/locationiq/geocoder_test.go
@@ -30,7 +30,6 @@ func TestGeocodeYieldsResult(t *testing.T) {
 	}
 }
 
-/* TODO uncomment as soon as the propagated error from client is returned
 func TestGeocodeYieldsNoResult(t *testing.T) {
 	ts := testServer("[]")
 	defer ts.Close()
@@ -38,17 +37,15 @@ func TestGeocodeYieldsNoResult(t *testing.T) {
 	gc := Geocoder("foobar", 18, ts.URL+"/")
 	l, err := gc.Geocode("Seidlstraße 26, 80335 München")
 
-	if err == nil {
-		t.Fatal("Got nil error")
+	if l != nil {
+		t.Errorf("Expected nil, got %#v", l)
 	}
-	if l.Lat != 0 {
-		t.Errorf("Expected latitude: %d, got: %f", 0, l.Lat)
-	}
-	if l.Lng != 0 {
-		t.Errorf("Expected longitude: %d, got: %f", 0, l.Lat)
+
+	if err != nil {
+		t.Errorf("Expected nil error, got %v", err)
 	}
 }
-*/
+
 func TestReverseGeocodeYieldsResult(t *testing.T) {
 	ts := testServer(responseForReverse)
 	defer ts.Close()
@@ -64,7 +61,6 @@ func TestReverseGeocodeYieldsResult(t *testing.T) {
 	}
 }
 
-/* TODO uncomment as soon as the propagated error from client is returned
 func TestReverseGeocodeYieldsNoResult(t *testing.T) {
 	ts := testServer(errorResponse)
 	defer ts.Close()
@@ -79,7 +75,7 @@ func TestReverseGeocodeYieldsNoResult(t *testing.T) {
 		t.Errorf("Expected nil as address, got: %s", addr)
 	}
 }
-*/
+
 func testServer(response string) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 		resp.Write([]byte(response))

--- a/locationiq/geocoder_test.go
+++ b/locationiq/geocoder_test.go
@@ -30,6 +30,7 @@ func TestGeocodeYieldsResult(t *testing.T) {
 	}
 }
 
+/* TODO uncomment as soon as the propagated error from client is returned
 func TestGeocodeYieldsNoResult(t *testing.T) {
 	ts := testServer("[]")
 	defer ts.Close()
@@ -38,7 +39,7 @@ func TestGeocodeYieldsNoResult(t *testing.T) {
 	l, err := gc.Geocode("Seidlstraße 26, 80335 München")
 
 	if err == nil {
-		t.Error("Got nil error")
+		t.Fatal("Got nil error")
 	}
 	if l.Lat != 0 {
 		t.Errorf("Expected latitude: %d, got: %f", 0, l.Lat)
@@ -47,7 +48,7 @@ func TestGeocodeYieldsNoResult(t *testing.T) {
 		t.Errorf("Expected longitude: %d, got: %f", 0, l.Lat)
 	}
 }
-
+*/
 func TestReverseGeocodeYieldsResult(t *testing.T) {
 	ts := testServer(responseForReverse)
 	defer ts.Close()
@@ -63,6 +64,7 @@ func TestReverseGeocodeYieldsResult(t *testing.T) {
 	}
 }
 
+/* TODO uncomment as soon as the propagated error from client is returned
 func TestReverseGeocodeYieldsNoResult(t *testing.T) {
 	ts := testServer(errorResponse)
 	defer ts.Close()
@@ -77,7 +79,7 @@ func TestReverseGeocodeYieldsNoResult(t *testing.T) {
 		t.Errorf("Expected nil as address, got: %s", addr)
 	}
 }
-
+*/
 func testServer(response string) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 		resp.Write([]byte(response))

--- a/locationiq/geocoder_test.go
+++ b/locationiq/geocoder_test.go
@@ -58,7 +58,7 @@ func TestReverseGeocodeYieldsResult(t *testing.T) {
 	if err != nil {
 		t.Errorf("Expected nil error, got %v", err)
 	}
-	if !strings.HasPrefix(addr, "26, Seidlstraße") {
+	if !strings.HasPrefix(addr.FormattedAddress, "26, Seidlstraße") {
 		t.Errorf("Expected address string starting with %s, got string: %s", "26, Seidlstraße", addr)
 	}
 }
@@ -73,8 +73,8 @@ func TestReverseGeocodeYieldsNoResult(t *testing.T) {
 	if err == nil {
 		t.Error("Expected error, got nil")
 	}
-	if addr != "" {
-		t.Errorf("Expected empty string as address, got: %s", addr)
+	if addr != nil {
+		t.Errorf("Expected nil as address, got: %s", addr)
 	}
 }
 

--- a/mapbox/geocoder.go
+++ b/mapbox/geocoder.go
@@ -3,8 +3,9 @@ package mapbox
 
 import (
 	"fmt"
-	"github.com/codingsince1985/geo-golang"
 	"strings"
+
+	"github.com/codingsince1985/geo-golang"
 )
 
 type (

--- a/mapbox/geocoder_test.go
+++ b/mapbox/geocoder_test.go
@@ -2,14 +2,15 @@ package mapbox_test
 
 import (
 	"fmt"
-	"github.com/codingsince1985/geo-golang"
-	"github.com/codingsince1985/geo-golang/mapbox"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/codingsince1985/geo-golang"
+	"github.com/codingsince1985/geo-golang/mapbox"
+	"github.com/stretchr/testify/assert"
 )
 
 var token = os.Getenv("MAPBOX_API_KEY")
@@ -21,7 +22,7 @@ func TestGeocode(t *testing.T) {
 	geocoder := mapbox.Geocoder(token, ts.URL+"/")
 	location, err := geocoder.Geocode("60 Collins St, Melbourne VIC 3000")
 	assert.NoError(t, err)
-	assert.Equal(t, geo.Location{Lat: -37.813754, Lng: 144.971756}, location)
+	assert.Equal(t, geo.Location{Lat: -37.813754, Lng: 144.971756}, *location)
 }
 
 func TestReverseGeocode(t *testing.T) {
@@ -32,7 +33,7 @@ func TestReverseGeocode(t *testing.T) {
 	address, err := geocoder.ReverseGeocode(-37.813754, 144.971756)
 	assert.NoError(t, err)
 	fmt.Println(address)
-	assert.True(t, strings.Index(address, "60 Collins St") >= 0)
+	assert.True(t, strings.Index(address.FormattedAddress, "60 Collins St") >= 0)
 }
 
 func TestReverseGeocodeWithNoResult(t *testing.T) {
@@ -40,8 +41,9 @@ func TestReverseGeocodeWithNoResult(t *testing.T) {
 	defer ts.Close()
 
 	geocoder := mapbox.Geocoder(token, ts.URL+"/")
-	_, err := geocoder.ReverseGeocode(-37.813754, 164.971756)
-	assert.Equal(t, err, geo.ErrNoResult)
+	addr, err := geocoder.ReverseGeocode(-37.813754, 164.971756)
+	assert.Nil(t, err)
+	assert.Nil(t, addr)
 }
 
 func testServer(response string) *httptest.Server {

--- a/mapbox/geocoder_test.go
+++ b/mapbox/geocoder_test.go
@@ -1,7 +1,6 @@
 package mapbox_test
 
 import (
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -32,7 +31,6 @@ func TestReverseGeocode(t *testing.T) {
 	geocoder := mapbox.Geocoder(token, ts.URL+"/")
 	address, err := geocoder.ReverseGeocode(-37.813754, 144.971756)
 	assert.NoError(t, err)
-	fmt.Println(address)
 	assert.True(t, strings.Index(address.FormattedAddress, "60 Collins St") >= 0)
 }
 

--- a/mapquest/nominatim/geocoder.go
+++ b/mapquest/nominatim/geocoder.go
@@ -52,8 +52,8 @@ func (r *geocodeResponse) Location() (*geo.Location, error) {
 	}
 
 	return &geo.Location{
-		Lat: parseFloat(r.Lat),
-		Lng: parseFloat(r.Lon),
+		Lat: geo.ParseFloat(r.Lat),
+		Lng: geo.ParseFloat(r.Lon),
 	}, nil
 }
 
@@ -74,9 +74,4 @@ func (r *geocodeResponse) Address() (*geo.Address, error) {
 		Country:          r.Addr.Country,
 		CountryCode:      strings.ToUpper(r.Addr.CountryCode),
 	}, nil
-}
-
-func parseFloat(value string) float64 {
-	f, _ := strconv.ParseFloat(value, 64)
-	return f
 }

--- a/mapquest/nominatim/geocoder.go
+++ b/mapquest/nominatim/geocoder.go
@@ -3,7 +3,6 @@ package nominatim
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/codingsince1985/geo-golang"

--- a/mapquest/nominatim/geocoder_test.go
+++ b/mapquest/nominatim/geocoder_test.go
@@ -1,14 +1,15 @@
 package nominatim_test
 
 import (
-	"github.com/codingsince1985/geo-golang"
-	"github.com/codingsince1985/geo-golang/mapquest/nominatim"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/codingsince1985/geo-golang"
+	"github.com/codingsince1985/geo-golang/mapquest/nominatim"
+	"github.com/stretchr/testify/assert"
 )
 
 var key = os.Getenv("MAPQUEST_NOMINATUM_KEY")

--- a/mapquest/nominatim/geocoder_test.go
+++ b/mapquest/nominatim/geocoder_test.go
@@ -20,7 +20,7 @@ func TestGeocode(t *testing.T) {
 	geocoder := nominatim.Geocoder(key, ts.URL+"/")
 	location, err := geocoder.Geocode("60 Collins St, Melbourne VIC 3000")
 	assert.NoError(t, err)
-	assert.Equal(t, geo.Location{Lat: -37.8137433689794, Lng: 144.971745104488}, location)
+	assert.Equal(t, geo.Location{Lat: -37.8137433689794, Lng: 144.971745104488}, *location)
 }
 
 func TestReverseGeocode(t *testing.T) {
@@ -28,9 +28,9 @@ func TestReverseGeocode(t *testing.T) {
 	defer ts.Close()
 
 	geocoder := nominatim.Geocoder(key, ts.URL+"/")
-	address, err := geocoder.ReverseGeocode(-37.8137433689794, 144.971745104488)
+	addr, err := geocoder.ReverseGeocode(-37.8137433689794, 144.971745104488)
 	assert.NoError(t, err)
-	assert.True(t, strings.HasPrefix(address, "Reserve Bank of Australia"))
+	assert.True(t, strings.HasPrefix(addr.FormattedAddress, "Reserve Bank of Australia"))
 }
 
 func TestReverseGeocodeWithNoResult(t *testing.T) {
@@ -38,8 +38,10 @@ func TestReverseGeocodeWithNoResult(t *testing.T) {
 	defer ts.Close()
 
 	geocoder := nominatim.Geocoder(key, ts.URL+"/")
-	_, err := geocoder.ReverseGeocode(-37.8137433689794, 164.971745104488)
-	assert.Equal(t, err, geo.ErrNoResult)
+	//geocoder := nominatim.Geocoder(key)
+	addr, err := geocoder.ReverseGeocode(-37.8137433689794, 164.971745104488)
+	assert.NotNil(t, err)
+	assert.Nil(t, addr)
 }
 
 func testServer(response string) *httptest.Server {

--- a/mapquest/open/geocoder.go
+++ b/mapquest/open/geocoder.go
@@ -8,12 +8,22 @@ import (
 )
 
 type (
-	baseURL         string
+	baseURL string
+
 	geocodeResponse struct {
 		Results []struct {
 			Locations []struct {
-				LatLng                                     geo.Location
-				Street, AdminArea5, AdminArea3, AdminArea1 string
+				LatLng struct {
+					Lat float64
+					Lng float64
+				}
+				PostalCode string
+				Street     string
+				AdminArea6 string // neighbourhood
+				AdminArea5 string // city
+				AdminArea4 string // county
+				AdminArea3 string // state
+				AdminArea1 string // country (ISO 3166-1 alpha-2 code)
 			}
 		}
 	}
@@ -43,12 +53,37 @@ func (b baseURL) ReverseGeocodeURL(l geo.Location) string {
 	return strings.Replace(string(b), "*", "reverse", 1) + fmt.Sprintf("%f,%f", l.Lat, l.Lng)
 }
 
-func (r *geocodeResponse) Location() geo.Location { return r.Results[0].Locations[0].LatLng }
-
-func (r *geocodeResponse) Address() string {
-	p := r.Results[0].Locations[0]
-	if p.AdminArea1 != "" {
-		return p.Street + ", " + p.AdminArea5 + ", " + p.AdminArea3 + ", " + p.AdminArea1
+func (r *geocodeResponse) Location() (*geo.Location, error) {
+	if len(r.Results) == 0 || len(r.Results[0].Locations) == 0 {
+		return nil, nil
 	}
-	return ""
+
+	loc := r.Results[0].Locations[0].LatLng
+	return &geo.Location{
+		Lat: loc.Lat,
+		Lng: loc.Lng,
+	}, nil
+}
+
+func (r *geocodeResponse) Address() (*geo.Address, error) {
+	if len(r.Results) == 0 || len(r.Results[0].Locations) == 0 {
+		return nil, nil
+	}
+
+	p := r.Results[0].Locations[0]
+	if p.Street == "" || p.AdminArea5 == "" {
+		return nil, nil
+	}
+
+	formattedAddress := p.Street + ", " + p.PostalCode + ", " + p.AdminArea5 + ", " + p.AdminArea3 + ", " + p.AdminArea1
+	return &geo.Address{
+		FormattedAddress: formattedAddress,
+		Street:           p.Street,
+		Suburb:           p.AdminArea6,
+		Postcode:         p.PostalCode,
+		City:             p.AdminArea5,
+		County:           p.AdminArea4,
+		State:            p.AdminArea3,
+		CountryCode:      p.AdminArea1,
+	}, nil
 }

--- a/mapquest/open/geocoder.go
+++ b/mapquest/open/geocoder.go
@@ -9,7 +9,6 @@ import (
 
 type (
 	baseURL string
-
 	geocodeResponse struct {
 		Results []struct {
 			Locations []struct {

--- a/mapquest/open/geocoder.go
+++ b/mapquest/open/geocoder.go
@@ -3,12 +3,13 @@ package open
 
 import (
 	"fmt"
-	"github.com/codingsince1985/geo-golang"
 	"strings"
+
+	"github.com/codingsince1985/geo-golang"
 )
 
 type (
-	baseURL string
+	baseURL         string
 	geocodeResponse struct {
 		Results []struct {
 			Locations []struct {

--- a/mapquest/open/geocoder_test.go
+++ b/mapquest/open/geocoder_test.go
@@ -20,7 +20,7 @@ func TestGeocode(t *testing.T) {
 	geocoder := open.Geocoder(key, ts.URL+"/")
 	location, err := geocoder.Geocode("60 Collins St, Melbourne VIC 3000")
 	assert.NoError(t, err)
-	assert.Equal(t, geo.Location{Lat: -37.813743, Lng: 144.971745}, location)
+	assert.Equal(t, geo.Location{Lat: -37.813743, Lng: 144.971745}, *location)
 }
 
 func TestReverseGeocode(t *testing.T) {
@@ -30,7 +30,7 @@ func TestReverseGeocode(t *testing.T) {
 	geocoder := open.Geocoder(key, ts.URL+"/")
 	address, err := geocoder.ReverseGeocode(-37.813743, 144.971745)
 	assert.NoError(t, err)
-	assert.True(t, strings.HasPrefix(address, "Exhibition Street"))
+	assert.True(t, strings.HasPrefix(address.FormattedAddress, "Exhibition Street"))
 }
 
 func TestReverseGeocodeWithNoResult(t *testing.T) {
@@ -38,8 +38,10 @@ func TestReverseGeocodeWithNoResult(t *testing.T) {
 	defer ts.Close()
 
 	geocoder := open.Geocoder(key, ts.URL+"/")
-	_, err := geocoder.ReverseGeocode(-37.813743, 164.971745)
-	assert.Equal(t, err, geo.ErrNoResult)
+	//geocoder := open.Geocoder(key)
+	addr, err := geocoder.ReverseGeocode(-37.813743, 164.971745)
+	assert.Equal(t, err, nil)
+	assert.Nil(t, addr)
 }
 
 func testServer(response string) *httptest.Server {

--- a/mapquest/open/geocoder_test.go
+++ b/mapquest/open/geocoder_test.go
@@ -40,7 +40,7 @@ func TestReverseGeocodeWithNoResult(t *testing.T) {
 	geocoder := open.Geocoder(key, ts.URL+"/")
 	//geocoder := open.Geocoder(key)
 	addr, err := geocoder.ReverseGeocode(-37.813743, 164.971745)
-	assert.Equal(t, err, nil)
+	assert.Nil(t, err)
 	assert.Nil(t, addr)
 }
 

--- a/mapquest/open/geocoder_test.go
+++ b/mapquest/open/geocoder_test.go
@@ -1,14 +1,15 @@
 package open_test
 
 import (
-	"github.com/codingsince1985/geo-golang"
-	"github.com/codingsince1985/geo-golang/mapquest/open"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/codingsince1985/geo-golang"
+	"github.com/codingsince1985/geo-golang/mapquest/open"
+	"github.com/stretchr/testify/assert"
 )
 
 var key = os.Getenv("MAPQUEST_OPEN_KEY")

--- a/opencage/geocoder.go
+++ b/opencage/geocoder.go
@@ -69,12 +69,6 @@ func (r *geocodeResponse) Address() (*geo.Address, error) {
 	}
 
 	addr := r.Results[0].Components
-	var locality string
-	if addr.City != "" {
-		locality = addr.City
-	} else {
-		locality = addr.Village
-	}
 
 	return &geo.Address{
 		FormattedAddress: r.Results[0].Formatted,

--- a/opencage/geocoder.go
+++ b/opencage/geocoder.go
@@ -12,29 +12,29 @@ type (
 	baseURL string
 
 	geocodeResponse struct {
-	Results []struct {
-		Formatted  string
-		Geometry   geo.Location
-		Components osmAddress
-	}
-	Status struct {
-		Code    int
-		Message string
-	}
+		Results []struct {
+			Formatted  string
+			Geometry   geo.Location
+			Components osmAddress
+		}
+		Status struct {
+			Code    int
+			Message string
+		}
 	}
 
 	osmAddress struct {
-	HouseNumber   string `json:"house_number"`
-	Suburb        string `json:"suburb"`
-	City          string `json:"city"`
-	Village       string `json:"village"`
-	County        string `json:"county"`
-	Country       string `json:"country"`
-	CountryCode   string `json:"country_code"`
-	Road          string `json:"road"`
-	State         string `json:"state"`
-	StateDistrict string `json:"state_district"`
-	Postcode      string `json:"postcode"`
+		HouseNumber   string `json:"house_number"`
+		Suburb        string `json:"suburb"`
+		City          string `json:"city"`
+		Village       string `json:"village"`
+		County        string `json:"county"`
+		Country       string `json:"country"`
+		CountryCode   string `json:"country_code"`
+		Road          string `json:"road"`
+		State         string `json:"state"`
+		StateDistrict string `json:"state_district"`
+		Postcode      string `json:"postcode"`
 	}
 )
 

--- a/opencage/geocoder.go
+++ b/opencage/geocoder.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/codingsince1985/geo-golang"
+	"github.com/codingsince1985/geo-golang/osm"
 )
 
 type (
@@ -15,26 +16,12 @@ type (
 		Results []struct {
 			Formatted  string
 			Geometry   geo.Location
-			Components osmAddress
+			Components osm.Address
 		}
 		Status struct {
 			Code    int
 			Message string
 		}
-	}
-
-	osmAddress struct {
-		HouseNumber   string `json:"house_number"`
-		Suburb        string `json:"suburb"`
-		City          string `json:"city"`
-		Village       string `json:"village"`
-		County        string `json:"county"`
-		Country       string `json:"country"`
-		CountryCode   string `json:"country_code"`
-		Road          string `json:"road"`
-		State         string `json:"state"`
-		StateDistrict string `json:"state_district"`
-		Postcode      string `json:"postcode"`
 	}
 )
 
@@ -92,10 +79,10 @@ func (r *geocodeResponse) Address() (*geo.Address, error) {
 	return &geo.Address{
 		FormattedAddress: r.Results[0].Formatted,
 		HouseNumber:      addr.HouseNumber,
-		Street:           addr.Road,
+		Street:           addr.Street(),
 		Suburb:           addr.Suburb,
 		Postcode:         addr.Postcode,
-		City:             locality,
+		City:             addr.Locality(),
 		CountryCode:      strings.ToUpper(addr.CountryCode),
 		Country:          addr.Country,
 		County:           addr.County,

--- a/opencage/geocoder_test.go
+++ b/opencage/geocoder_test.go
@@ -1,14 +1,14 @@
 package opencage_test
 
 import (
-	"github.com/codingsince1985/geo-golang"
-	"github.com/codingsince1985/geo-golang/opencage"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/codingsince1985/geo-golang/opencage"
+	"github.com/stretchr/testify/assert"
 )
 
 var key = os.Getenv("OPENCAGE_API_KEY")
@@ -23,7 +23,7 @@ func TestGeocode(t *testing.T) {
 
 	geocoder := opencage.Geocoder(key, ts.URL+"/")
 	location, err := geocoder.Geocode("60 Collins St, Melbourne VIC 3000")
-	assert.NoError(t, err)
+	assert.Nil(t, err)
 	assert.InDelta(t, -37.8154176, location.Lat, locDelta)
 	assert.InDelta(t, 144.9665563, location.Lng, locDelta)
 }
@@ -35,7 +35,7 @@ func TestReverseGeocode(t *testing.T) {
 	geocoder := opencage.Geocoder(key, ts.URL+"/")
 	address, err := geocoder.ReverseGeocode(-37.8154176, 144.9665563)
 	assert.NoError(t, err)
-	assert.True(t, strings.Index(address, "Collins St") > 0)
+	assert.True(t, strings.Index(address.FormattedAddress, "Collins St") > 0)
 }
 
 func TestReverseGeocodeWithNoResult(t *testing.T) {
@@ -43,8 +43,10 @@ func TestReverseGeocodeWithNoResult(t *testing.T) {
 	defer ts.Close()
 
 	geocoder := opencage.Geocoder(key, ts.URL+"/")
-	_, err := geocoder.ReverseGeocode(-37.8154176, 164.9665563)
-	assert.Equal(t, err, geo.ErrNoResult)
+	//geocoder := opencage.Geocoder(key)
+	address, err := geocoder.ReverseGeocode(-37.8154176, 164.9665563)
+	assert.Nil(t, err)
+	assert.Nil(t, address)
 }
 
 func testServer(response string) *httptest.Server {

--- a/openstreetmap/geocoder.go
+++ b/openstreetmap/geocoder.go
@@ -3,32 +3,19 @@ package openstreetmap
 
 import (
 	"fmt"
-	"strings"
 	"github.com/codingsince1985/geo-golang"
+	"github.com/codingsince1985/geo-golang/osm"
+	"strings"
 )
 
 type (
-	baseURL string
+	baseURL         string
 	geocodeResponse struct {
-	DisplayName string `json:"display_name"`
-	Lat         string
-	Lon         string
-	Error       string
-	Addr        osmAddress `json:"address"`
-	}
-
-	osmAddress struct {
-	HouseNumber   string `json:"house_number"`
-	Suburb        string `json:"suburb"`
-	City          string `json:"city"`
-	Village       string `json:"village"`
-	County        string `json:"county"`
-	Country       string `json:"country"`
-	CountryCode   string `json:"country_code"`
-	Road          string `json:"road"`
-	State         string `json:"state"`
-	StateDistrict string `json:"state_district"`
-	Postcode      string `json:"postcode"`
+		DisplayName string `json:"display_name"`
+		Lat         string
+		Lon         string
+		Error       string
+		Addr        osm.Address `json:"address"`
 	}
 )
 
@@ -69,18 +56,13 @@ func (r *geocodeResponse) Address() (*geo.Address, error) {
 	if r.Error != "" {
 		return nil, fmt.Errorf("reverse geocoding error: %s", r.Error)
 	}
-	var locality string
-	if r.Addr.City != "" {
-		locality = r.Addr.City
-	} else {
-		locality = r.Addr.Village
-	}
+
 	return &geo.Address{
 		FormattedAddress: r.DisplayName,
 		HouseNumber:      r.Addr.HouseNumber,
-		Street:           r.Addr.Road,
+		Street:           r.Addr.Street(),
 		Postcode:         r.Addr.Postcode,
-		City:             locality,
+		City:             r.Addr.Locality(),
 		Suburb:           r.Addr.Suburb,
 		State:            r.Addr.State,
 		Country:          r.Addr.Country,

--- a/openstreetmap/geocoder.go
+++ b/openstreetmap/geocoder.go
@@ -3,9 +3,10 @@ package openstreetmap
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/codingsince1985/geo-golang"
 	"github.com/codingsince1985/geo-golang/osm"
-	"strings"
 )
 
 type (

--- a/openstreetmap/geocoder.go
+++ b/openstreetmap/geocoder.go
@@ -3,14 +3,32 @@ package openstreetmap
 
 import (
 	"fmt"
+	"strings"
 	"github.com/codingsince1985/geo-golang"
 )
 
 type (
-	baseURL         string
+	baseURL string
 	geocodeResponse struct {
-		DisplayName     string `json:"display_name"`
-		Lat, Lon, Error string
+	DisplayName string `json:"display_name"`
+	Lat         string
+	Lon         string
+	Error       string
+	Addr        osmAddress `json:"address"`
+	}
+
+	osmAddress struct {
+	HouseNumber   string `json:"house_number"`
+	Suburb        string `json:"suburb"`
+	City          string `json:"city"`
+	Village       string `json:"village"`
+	County        string `json:"county"`
+	Country       string `json:"country"`
+	CountryCode   string `json:"country_code"`
+	Road          string `json:"road"`
+	State         string `json:"state"`
+	StateDistrict string `json:"state_district"`
+	Postcode      string `json:"postcode"`
 	}
 )
 
@@ -33,16 +51,39 @@ func (b baseURL) ReverseGeocodeURL(l geo.Location) string {
 	return string(b) + "reverse?" + fmt.Sprintf("format=json&lat=%f&lon=%f", l.Lat, l.Lng)
 }
 
-func (r *geocodeResponse) Location() geo.Location {
-	if r.Error == "" {
-		return geo.Location{geo.ParseFloat(r.Lat), geo.ParseFloat(r.Lon)}
+func (r *geocodeResponse) Location() (*geo.Location, error) {
+	if r.Error != "" {
+		return nil, fmt.Errorf("geocoding error: %s", r.Error)
 	}
-	return geo.Location{}
+	if r.Lat == "" && r.Lon == "" {
+		return nil, nil
+	}
+
+	return &geo.Location{
+		Lat: geo.ParseFloat(r.Lat),
+		Lng: geo.ParseFloat(r.Lon),
+	}, nil
 }
 
-func (r *geocodeResponse) Address() string {
-	if r.Error == "" {
-		return r.DisplayName
+func (r *geocodeResponse) Address() (*geo.Address, error) {
+	if r.Error != "" {
+		return nil, fmt.Errorf("reverse geocoding error: %s", r.Error)
 	}
-	return ""
+	var locality string
+	if r.Addr.City != "" {
+		locality = r.Addr.City
+	} else {
+		locality = r.Addr.Village
+	}
+	return &geo.Address{
+		FormattedAddress: r.DisplayName,
+		HouseNumber:      r.Addr.HouseNumber,
+		Street:           r.Addr.Road,
+		Postcode:         r.Addr.Postcode,
+		City:             locality,
+		Suburb:           r.Addr.Suburb,
+		State:            r.Addr.State,
+		Country:          r.Addr.Country,
+		CountryCode:      strings.ToUpper(r.Addr.CountryCode),
+	}, nil
 }

--- a/openstreetmap/geocoder_test.go
+++ b/openstreetmap/geocoder_test.go
@@ -17,8 +17,8 @@ func TestGeocode(t *testing.T) {
 
 	geocoder := openstreetmap.GeocoderWithURL(ts.URL + "/")
 	location, err := geocoder.Geocode("60 Collins St, Melbourne VIC 3000")
-	assert.NoError(t, err)
-	assert.Equal(t, geo.Location{Lat: -37.8157915, Lng: 144.9656171}, location)
+	assert.Nil(t, err)
+	assert.Equal(t, geo.Location{Lat: -37.8157915, Lng: 144.9656171}, *location)
 }
 
 func TestReverseGeocode(t *testing.T) {
@@ -27,8 +27,8 @@ func TestReverseGeocode(t *testing.T) {
 
 	geocoder := openstreetmap.GeocoderWithURL(ts.URL + "/")
 	address, err := geocoder.ReverseGeocode(-37.8157915, 144.9656171)
-	assert.NoError(t, err)
-	assert.True(t, strings.Index(address, "Collins St") > 0)
+	assert.Nil(t, err)
+	assert.True(t, strings.Index(address.FormattedAddress, "Collins St") > 0)
 }
 
 func TestReverseGeocodeWithNoResult(t *testing.T) {
@@ -36,8 +36,10 @@ func TestReverseGeocodeWithNoResult(t *testing.T) {
 	defer ts.Close()
 
 	geocoder := openstreetmap.GeocoderWithURL(ts.URL + "/")
-	_, err := geocoder.ReverseGeocode(-37.8157915, 164.9656171)
-	assert.Equal(t, err, geo.ErrNoResult)
+	//geocoder := openstreetmap.Geocoder()
+	addr, err := geocoder.ReverseGeocode(-37.8157915, 164.9656171)
+	assert.Nil(t, err)
+	assert.Nil(t, addr)
 }
 
 func testServer(response string) *httptest.Server {

--- a/openstreetmap/geocoder_test.go
+++ b/openstreetmap/geocoder_test.go
@@ -38,8 +38,8 @@ func TestReverseGeocodeWithNoResult(t *testing.T) {
 	geocoder := openstreetmap.GeocoderWithURL(ts.URL + "/")
 	//geocoder := openstreetmap.Geocoder()
 	addr, err := geocoder.ReverseGeocode(-37.8157915, 164.9656171)
-	assert.Nil(t, err)
 	assert.Nil(t, addr)
+	assert.NotNil(t, err)
 }
 
 func testServer(response string) *httptest.Server {

--- a/osm/osm.go
+++ b/osm/osm.go
@@ -1,0 +1,57 @@
+// Package osm provides common types for OpneStreetMap used by various providers
+// and some helper functions to reduce code repetition across specific client implementations.
+package osm
+
+// OSMAddress contains address fields specific to OpenStreetMap
+type OSMAddress struct {
+	HouseNumber   string `json:"house_number"`
+	Road          string `json:"road"`
+	Pedestrian    string `json:"pedestrian"`
+	Cycleway      string `json:"cycleway"`
+	Highway       string `json:"highway"`
+	Path          string `json:"path"`
+	Suburb        string `json:"suburb"`
+	City          string `json:"city"`
+	Town          string `json:"town"`
+	Village       string `json:"village"`
+	County        string `json:"county"`
+	Country       string `json:"country"`
+	CountryCode   string `json:"country_code"`
+	State         string `json:"state"`
+	StateDistrict string `json:"state_district"`
+	Postcode      string `json:"postcode"`
+}
+
+// Locality checks different fields for the locality name
+func (a OSMAddress) Locality() string {
+	var locality string
+
+	if a.City != "" {
+		locality = a.City
+	} else if a.Town != "" {
+		locality = a.Town
+	} else if a.Village != "" {
+		locality = a.Village
+	}
+
+	return locality
+}
+
+// Street checks different fields for the street name
+func (a OSMAddress) Street() string {
+	var street string
+
+	if a.Road != "" {
+		street = a.Road
+	} else if a.Pedestrian != "" {
+		street = a.Pedestrian
+	} else if a.Path != "" {
+		street = a.Path
+	} else if a.Cycleway != "" {
+		street = a.Cycleway
+	} else if a.Highway != "" {
+		street = a.Highway
+	}
+
+	return street
+}

--- a/osm/osm.go
+++ b/osm/osm.go
@@ -2,8 +2,8 @@
 // and some helper functions to reduce code repetition across specific client implementations.
 package osm
 
-// OSMAddress contains address fields specific to OpenStreetMap
-type OSMAddress struct {
+// Address contains address fields specific to OpenStreetMap
+type Address struct {
 	HouseNumber   string `json:"house_number"`
 	Road          string `json:"road"`
 	Pedestrian    string `json:"pedestrian"`
@@ -23,7 +23,7 @@ type OSMAddress struct {
 }
 
 // Locality checks different fields for the locality name
-func (a OSMAddress) Locality() string {
+func (a Address) Locality() string {
 	var locality string
 
 	if a.City != "" {
@@ -38,7 +38,7 @@ func (a OSMAddress) Locality() string {
 }
 
 // Street checks different fields for the street name
-func (a OSMAddress) Street() string {
+func (a Address) Street() string {
 	var street string
 
 	if a.Road != "" {

--- a/osm/osm.go
+++ b/osm/osm.go
@@ -7,6 +7,7 @@ type Address struct {
 	HouseNumber   string `json:"house_number"`
 	Road          string `json:"road"`
 	Pedestrian    string `json:"pedestrian"`
+	Footway       string `json:"footway"`
 	Cycleway      string `json:"cycleway"`
 	Highway       string `json:"highway"`
 	Path          string `json:"path"`
@@ -49,6 +50,8 @@ func (a Address) Street() string {
 		street = a.Path
 	} else if a.Cycleway != "" {
 		street = a.Cycleway
+	} else if a.Footway != "" {
+		street = a.Footway
 	} else if a.Highway != "" {
 		street = a.Highway
 	}

--- a/osm/osm.go
+++ b/osm/osm.go
@@ -1,4 +1,4 @@
-// Package osm provides common types for OpneStreetMap used by various providers
+// Package osm provides common types for OpenStreetMap used by various providers
 // and some helper functions to reduce code repetition across specific client implementations.
 package osm
 


### PR DESCRIPTION
PR to solve [issue #29](https://github.com/codingsince1985/geo-golang/issues/29) 

It's been a while, but with Christmas, work and family added to the fact I had to sign up for many of the providers, the library supports, look into the documentation of their API, etc...

To sum up the major changes I made:

- use `context.Context` with a timeout instead of `time.After` with the benefit of cleaning up / releasing resources in case the deadline has been reached
- moved the structures `geo.Location` and `geo.Address` to `geocoder.go`, where the definition of the interface is placed, since these are part of the interface's contract and also to reduce the LOC in `http_geocoder.go`
- no longer using `ErrNoResults`, this can be now deduced if the returned values are `nil, nil`; in case an error has been returned by the provider (only few really do so) it's then translated in the second return value
- moved the examples code from `geocoder_test.go` to `examples/geocoder_example.go` to not be mistaken with unit tests, because of language specific conventions

In case of further questions / concerns, I'll be glad to discuss them.

Cheers