### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ func try(geocoder geo.Geocoder) {
 	fmt.Println("\n")
 }
 ```
-###Result
+### Result
 ```
 Google Geocoding API
 Melbourne VIC location is (-37.813611, 144.963056)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
