### PR TITLE
Add PickPoint provider.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This product is designed to open to any Geocoding service. Based on it,
 + [Bing](https://msdn.microsoft.com/en-us/library/ff701715.aspx)
 + [Mapbox](https://www.mapbox.com/developers/api/geocoding/)
 + [OpenStreetMap](https://wiki.openstreetmap.org/wiki/Nominatim)
++ [PickPoint](https://pickpoint.io)
 + [LocationIQ](http://locationiq.org/)
 
 clients are implemented in ~50 LoC each.
@@ -39,8 +40,9 @@ import (
 	"github.com/codingsince1985/geo-golang/opencage"
 	"github.com/codingsince1985/geo-golang/mapbox"
 	"github.com/codingsince1985/geo-golang/openstreetmap"
-	"github.com/codingsince1985/geo-golang/chained"
+	"github.com/codingsince1985/geo-golang/pickpoint"
 	"github.com/codingsince1985/geo-golang/locationiq"
+	"github.com/codingsince1985/geo-golang/chained"
 )
 
 const (
@@ -78,6 +80,9 @@ func ExampleGeocoder() {
 
 	fmt.Println("OpenStreetMap")
 	try(openstreetmap.Geocoder())
+	
+    fmt.Println("PickPoint")
+    try(pickpoint.Geocoder(os.Getenv("PICKPOINT_API_KEY")))
 
 	fmt.Println("LocationIQ")
 	try(locationiq.Geocoder(os.Getenv("LOCATIONIQ_API_KEY"), ZOOM))
@@ -145,6 +150,11 @@ Address of (-37.813611,144.963056) is Elwood Park Playground, Melbourne, Victori
 Detailed address: &geo.Address{FormattedAddress:"Elwood Park Playground, Melbourne, Victoria 3000, Australia", Street:"Elwood Park Playground", HouseNumber:"", Suburb:"", Postcode:"3000", State:"Victoria", StateDistrict:"", County:"", Country:"Australia", CountryCode:"AU", City:"Melbourne"}
 
 OpenStreetMap
+Melbourne VIC location is (-37.814217, 144.963161)
+Address of (-37.813611,144.963056) is Melbourne's GPO, Postal Lane, Chinatown, Melbourne, City of Melbourne, Greater Melbourne, Victoria, 3000, Australia
+Detailed address: &geo.Address{FormattedAddress:"Melbourne's GPO, Postal Lane, Chinatown, Melbourne, City of Melbourne, Greater Melbourne, Victoria, 3000, Australia", Street:"Postal Lane", HouseNumber:"", Suburb:"Melbourne", Postcode:"3000", State:"Victoria", StateDistrict:"", County:"", Country:"Australia", CountryCode:"AU", City:"Melbourne"}
+
+PickPoint
 Melbourne VIC location is (-37.814217, 144.963161)
 Address of (-37.813611,144.963056) is Melbourne's GPO, Postal Lane, Chinatown, Melbourne, City of Melbourne, Greater Melbourne, Victoria, 3000, Australia
 Detailed address: &geo.Address{FormattedAddress:"Melbourne's GPO, Postal Lane, Chinatown, Melbourne, City of Melbourne, Greater Melbourne, Victoria, 3000, Australia", Street:"Postal Lane", HouseNumber:"", Suburb:"Melbourne", Postcode:"3000", State:"Victoria", StateDistrict:"", County:"", Country:"Australia", CountryCode:"AU", City:"Melbourne"}

--- a/examples/geocoder_example.go
+++ b/examples/geocoder_example.go
@@ -15,6 +15,7 @@ import (
 	"github.com/codingsince1985/geo-golang/mapquest/open"
 	"github.com/codingsince1985/geo-golang/opencage"
 	"github.com/codingsince1985/geo-golang/openstreetmap"
+	"github.com/codingsince1985/geo-golang/pickpoint"
 )
 
 const (
@@ -53,6 +54,9 @@ func ExampleGeocoder() {
 
 	fmt.Println("OpenStreetMap")
 	try(openstreetmap.Geocoder())
+
+	fmt.Println("PickPoint")
+	try(pickpoint.Geocoder(os.Getenv("PICKPOINT_API_KEY")))
 
 	fmt.Println("LocationIQ")
 	try(locationiq.Geocoder(os.Getenv("LOCATIONIQ_API_KEY"), zoom))
@@ -112,6 +116,13 @@ func ExampleGeocoder() {
 	// 	County:"", Country:"Australia", CountryCode:"AU", City:"Melbourne"}
 	//
 	// OpenStreetMap
+	// Melbourne VIC location is (-37.814217, 144.963161)
+	// Address of (-37.813611,144.963056) is Melbourne's GPO, Postal Lane, Chinatown, Melbourne, City of Melbourne, Greater Melbourne, Victoria, 3000, Australia
+	// Detailed address: &geo.Address{FormattedAddress:"Melbourne's GPO, Postal Lane, Chinatown, Melbourne, City of Melbourne, Greater Melbourne,
+	// 	Victoria, 3000, Australia", Street:"Postal Lane", HouseNumber:"", Suburb:"Melbourne", Postcode:"3000", State:"Victoria",
+	// 	StateDistrict:"", County:"", Country:"Australia", CountryCode:"AU", City:"Melbourne"}
+	//
+	// PickPoint
 	// Melbourne VIC location is (-37.814217, 144.963161)
 	// Address of (-37.813611,144.963056) is Melbourne's GPO, Postal Lane, Chinatown, Melbourne, City of Melbourne, Greater Melbourne, Victoria, 3000, Australia
 	// Detailed address: &geo.Address{FormattedAddress:"Melbourne's GPO, Postal Lane, Chinatown, Melbourne, City of Melbourne, Greater Melbourne,

--- a/pickpoint/geocoder.go
+++ b/pickpoint/geocoder.go
@@ -1,0 +1,79 @@
+// Package pickpoint is a geo-golang based PickPoint geocode/reverse geocode client
+package pickpoint
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/codingsince1985/geo-golang"
+	"github.com/codingsince1985/geo-golang/osm"
+)
+
+type (
+	baseURL         string
+	geocodeResponse struct {
+		DisplayName string `json:"display_name"`
+		Lat         string
+		Lon         string
+		Error       string
+		Addr        osm.Address `json:"address"`
+	}
+)
+
+var key string
+
+// Geocoder constructs PickPoint geocoder
+func Geocoder(apiKey string, baseURLs ...string) geo.Geocoder {
+	key = apiKey
+	return geo.HTTPGeocoder{
+		EndpointBuilder:       baseURL(getURL(baseURLs...)),
+		ResponseParserFactory: func() geo.ResponseParser { return &geocodeResponse{} },
+	}
+}
+
+func getURL(baseURLs ...string) string {
+	if len(baseURLs) > 0 {
+		return baseURLs[0]
+	}
+	return "https://api.pickpoint.io/v1"
+}
+
+func (b baseURL) GeocodeURL(address string) string {
+	return string(b) + fmt.Sprintf("/forward?key=%s&limit=1&q=%s", key, address)
+}
+
+func (b baseURL) ReverseGeocodeURL(l geo.Location) string {
+	return string(b) + fmt.Sprintf("/reverse?key=%s&lat=%f&lon=%f", key, l.Lat, l.Lng)
+}
+
+func (r *geocodeResponse) Location() (*geo.Location, error) {
+	if r.Error != "" {
+		return nil, fmt.Errorf("geocoding error: %s", r.Error)
+	}
+	if r.Lat == "" && r.Lon == "" {
+		return nil, nil
+	}
+
+	return &geo.Location{
+		Lat: geo.ParseFloat(r.Lat),
+		Lng: geo.ParseFloat(r.Lon),
+	}, nil
+}
+
+func (r *geocodeResponse) Address() (*geo.Address, error) {
+	if r.Error != "" {
+		return nil, fmt.Errorf("reverse geocoding error: %s", r.Error)
+	}
+
+	return &geo.Address{
+		FormattedAddress: r.DisplayName,
+		HouseNumber:      r.Addr.HouseNumber,
+		Street:           r.Addr.Street(),
+		Postcode:         r.Addr.Postcode,
+		City:             r.Addr.Locality(),
+		Suburb:           r.Addr.Suburb,
+		State:            r.Addr.State,
+		Country:          r.Addr.Country,
+		CountryCode:      strings.ToUpper(r.Addr.CountryCode),
+	}, nil
+}

--- a/pickpoint/geocoder_test.go
+++ b/pickpoint/geocoder_test.go
@@ -1,0 +1,103 @@
+package pickpoint_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"net/http"
+	"net/http/httptest"
+	"github.com/stretchr/testify/assert"
+	"github.com/codingsince1985/geo-golang"
+	"github.com/codingsince1985/geo-golang/pickpoint"
+)
+
+var key = os.Getenv("PICKPOINT_API_KEY")
+
+func TestGeocode(t *testing.T) {
+	ts := testServer(response1)
+	defer ts.Close()
+
+	geocoder := pickpoint.Geocoder(key, ts.URL + "/")
+	location, err := geocoder.Geocode("60 Collins St, Melbourne VIC 3000")
+	assert.Nil(t, err)
+	assert.Equal(t, geo.Location{Lat: -37.8157915, Lng: 144.9656171}, *location)
+}
+
+func TestReverseGeocode(t *testing.T) {
+	ts := testServer(response2)
+	defer ts.Close()
+
+	geocoder := pickpoint.Geocoder(key, ts.URL + "/")
+	address, err := geocoder.ReverseGeocode(-37.8157915, 144.9656171)
+	assert.Nil(t, err)
+	assert.True(t, strings.Index(address.FormattedAddress, "Collins St") > 0)
+}
+
+func TestReverseGeocodeWithNoResult(t *testing.T) {
+	ts := testServer(response3)
+	defer ts.Close()
+
+	geocoder := pickpoint.Geocoder(key, ts.URL + "/")
+	addr, err := geocoder.ReverseGeocode(-37.8157915, 164.9656171)
+	assert.Nil(t, addr)
+	assert.NotNil(t, err)
+}
+
+func testServer(response string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+		resp.Write([]byte(response))
+	}))
+}
+
+const (
+	response1 = `[
+   {
+      "place_id":"133372311",
+      "licence":"Data © OpenStreetMap contributors, ODbL 1.0. http:\/\/www.openstreetmap.org\/copyright",
+      "osm_type":"way",
+      "osm_id":"316166613",
+      "boundingbox":[
+         "-37.8162553",
+         "-37.815533",
+         "144.9640149",
+         "144.9665099"
+      ],
+      "lat":"-37.8157915",
+      "lon":"144.9656171",
+      "display_name":"Collins Street, Melbourne, City of Melbourne, Greater Melbourne, Victoria, 3000, Australia",
+      "class":"highway",
+      "type":"tertiary",
+      "importance":0.51
+   }
+]`
+	response2 = `{
+   "place_id":"5122082",
+   "licence":"Data © OpenStreetMap contributors, ODbL 1.0. http:\/\/www.openstreetmap.org\/copyright",
+   "osm_type":"node",
+   "osm_id":"594206614",
+   "lat":"-37.8158091",
+   "lon":"144.9656492",
+   "display_name":"Telstra, Collins Street, Melbourne, City of Melbourne, Greater Melbourne, Victoria, 3000, Australia",
+   "address":{
+      "telephone":"Telstra",
+      "road":"Collins Street",
+      "suburb":"Melbourne",
+      "city":"Melbourne",
+      "county":"City of Melbourne",
+      "region":"Greater Melbourne",
+      "state":"Victoria",
+      "postcode":"3000",
+      "country":"Australia",
+      "country_code":"au"
+   },
+   "boundingbox":[
+      "-37.8159091",
+      "-37.8157091",
+      "144.9655492",
+      "144.9657492"
+   ]
+}`
+	response3 = `{
+   "error":"Unable to geocode"
+}`
+)


### PR DESCRIPTION
This PR adds PickPoint geocoder, which is commercial version of Nominatim hosted at [https://pickpoint.io](https://pickpoint.io).