### PR TITLE
print payload when an error is received in response method

### DIFF
--- a/geocoder.go
+++ b/geocoder.go
@@ -1,6 +1,11 @@
 // Package geo is a generic framework to develop geocode/reverse geocode clients
 package geo
 
+import (
+	"io/ioutil"
+	"log"
+)
+
 // Geocoder can look up (lat, long) by address and address by (lat, long)
 type Geocoder interface {
 	Geocode(address string) (*Location, error)
@@ -26,4 +31,12 @@ type Address struct {
 	Country          string
 	CountryCode      string
 	City             string
+}
+
+// Logger is an implementation of StdLogger that geo uses to log its messages.
+var Logger StdLogger = log.New(ioutil.Discard, "[Geo]", log.LstdFlags)
+
+// StdLogger is a interface for logging libraries.
+type StdLogger interface {
+	Printf(string, ...interface{})
 }

--- a/http_geocoder.go
+++ b/http_geocoder.go
@@ -135,6 +135,7 @@ func response(ctx context.Context, url string, obj ResponseParser) error {
 		return nil
 	}
 	if err := json.Unmarshal([]byte(body), obj); err != nil {
+		Logger.Printf("payload: %s", body)
 		return err
 	}
 

--- a/http_geocoder.go
+++ b/http_geocoder.go
@@ -135,7 +135,7 @@ func response(ctx context.Context, url string, obj ResponseParser) error {
 		return nil
 	}
 	if err := json.Unmarshal([]byte(body), obj); err != nil {
-		Logger.Printf("payload: %s", body)
+		Logger.Printf("payload: %s\n", body)
 		return err
 	}
 


### PR DESCRIPTION
we are using opencage as provider and some times when we do a request for it we receive this error `invalid character '<' looking for beginning of value` and would be nice if we could see the response from opencage.
So with this PR we create a Logger for those who use this library print the payload and it is flexible.