### PR TITLE
frenchapigouv : fixed street retrievement in case of type street or locality

### DIFF
--- a/frenchapigouv/geocoder.go
+++ b/frenchapigouv/geocoder.go
@@ -84,8 +84,12 @@ func (r *geocodeResponse) Address() (*geo.Address, error) {
 	}
 	p := r.Features[0].Properties
 	c := r.parseContext()
+
+	if p.Type == "street" || p.Type == "locality" {
+		p.Street = p.Name
+	}
 	return &geo.Address{
-		FormattedAddress: strings.Join(strings.Fields(strings.TrimSpace(fmt.Sprintf("%s, %s, %s, %s, %s, %s, %s", p.Housenumber, p.Street, p.Postcode, p.City, c.county, c.state, "France"))), " "),
+		FormattedAddress: strings.Join(strings.Fields(strings.Trim(fmt.Sprintf("%s, %s, %s, %s, %s, %s, %s", p.Housenumber, p.Street, p.Postcode, p.City, c.county, c.state, "France"), " ,")), " "),
 		HouseNumber:      p.Housenumber,
 		Street:           p.Street,
 		Postcode:         p.Postcode,

--- a/frenchapigouv/geocoder_test.go
+++ b/frenchapigouv/geocoder_test.go
@@ -44,6 +44,28 @@ func TestReverseGeocode(t *testing.T) {
 	assert.Equal(t, "Paris", address.County)
 }
 
+func TestReverseGeocodeWithTypeStreet(t *testing.T) {
+	ts := testServer(responseStreet)
+	defer ts.Close()
+	geocoder := frenchapigouv.GeocoderWithURL(ts.URL + "/")
+	address, err := geocoder.ReverseGeocode(50.720114, 3.156717)
+	assert.Nil(t, err)
+	assert.True(t, strings.HasPrefix(address.FormattedAddress, "Rue des Anges,"))
+	assert.Equal(t, "Hauts-de-France", address.State)
+	assert.Equal(t, "Nord", address.County)
+}
+
+func TestReverseGeocodeWithTypeLocality(t *testing.T) {
+	ts := testServer(responseLocality)
+	defer ts.Close()
+	geocoder := frenchapigouv.GeocoderWithURL(ts.URL + "/")
+	address, err := geocoder.ReverseGeocode(44.995637, 1.646584)
+	assert.Nil(t, err)
+	assert.True(t, strings.HasPrefix(address.FormattedAddress, "Route de Saint Denis les Martel (Les Quatre-Routes-du-Lot),"))
+	assert.Equal(t, "Occitanie", address.State)
+	assert.Equal(t, "Lot", address.County)
+}
+
 func TestReverseGeocodeWithNoResult(t *testing.T) {
 	ts := testServer(response2)
 	defer ts.Close()
@@ -134,5 +156,65 @@ const (
 		"attribution": "BAN",
 		"licence": "ODbL 1.0",
 		"limit": 1
+	}`
+	responseStreet = `{
+    	"type": "FeatureCollection",
+    	"version": "draft",
+    	"features": [{
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [3.156717,50.720114]
+            },
+            "properties": {
+                "label": "Rue des Anges 59200 Tourcoing",
+                "score": 0.7319487603305784,
+                "id": "59599_0310",
+                "name": "Rue des Anges",
+                "postcode": "59200",
+                "citycode": "59599",
+                "x": 711087.23,
+                "y": 7069277.25,
+                "city": "Tourcoing",
+                "context": "59, Nord, Hauts-de-France",
+                "type": "street",
+                "importance": 0.6878
+            }
+        }],
+    	"attribution": "BAN",
+    	"licence": "ETALAB-2.0",
+    	"query": "11B Rue des Anges Tourcoing 59200",
+    	"limit": 1
+	}`
+	responseLocality = `{
+    	"type": "FeatureCollection",
+    	"version": "draft",
+    	"features": [{
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [1.646584,44.995637]
+            },
+            "properties": {
+                "label": "Route de Saint Denis les Martel (Les Quatre-Routes-du-Lot) 46110 Le Vignon-en-Quercy",
+                "score": 0.8454463636363636,
+                "type": "locality",
+                "importance": 0.29991,
+                "id": "46232_0023",
+                "name": "Route de Saint Denis les Martel (Les Quatre-Routes-du-Lot)",
+                "postcode": "46110",
+                "citycode": "46232",
+                "oldcitycode": "46232",
+                "x": 593348.58,
+                "y": 6433848.43,
+                "city": "Le Vignon-en-Quercy",
+                "oldcity": "Les Quatre-Routes-du-Lot",
+                "context": "46, Lot, Occitanie"
+            }
+        }],
+    	"attribution": "BAN",
+    	"licence": "ETALAB-2.0",
+    	"query": "Route de Saint-Denis-lès-Martel",
+    	"limit": 1
 	}`
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/codingsince1985/geo-golang
+module github.com/loudmaker/geo-golang
 
 go 1.14
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/loudmaker/geo-golang
+module github.com/codingsince1985/geo-golang
 
 go 1.14
 


### PR DESCRIPTION
when object is a street or locality type. Street attribute doesn't exists.
So street attribute can be binded by:
- the 'name' attribute for street type.
- the 'name' attribute for 'locality' type.

updated 'FormattedAddress' with a trim ',' to ensure clean formattedAddress in case of empty attributes.