### PR TITLE
Add Amap Support to geo-golang

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,10 @@ func ExampleGeocoder() {
 	try(bing.Geocoder(os.Getenv("BING_API_KEY")))
 
 	fmt.Println("Baidu Geocoding API")
-	try(google.Geocoder(os.Getenv("BAIDU_API_KEY")))
+	try(baidu.Geocoder(os.Getenv("BAIDU_API_KEY")))
+
+	fmt.Println("Amap Geocoding API")
+	try(amap.Geocoder(os.Getenv("BAIDU_API_KEY")))
 
 	fmt.Println("Mapbox API")
 	try(mapbox.Geocoder(os.Getenv("MAPBOX_API_KEY")))

--- a/amap/amap.go
+++ b/amap/amap.go
@@ -1,0 +1,124 @@
+package amap
+
+import (
+	"encoding/xml"
+	"fmt"
+	"strings"
+
+	"github.com/codingsince1985/geo-golang"
+)
+
+type (
+	baseURL string
+	geocodeResponse struct {
+		XMLName  xml.Name `xml:"response"`
+		Status   int      `xml:"status"`
+		Info     string   `xml:"info"`
+		Infocode int      `xml:"infocode"`
+		Count    int      `xml:"count"`
+		Geocodes []struct {
+			FormattedAddress string `xml:"formatted_address"`
+			Country          string `xml:"country"`
+			Province         string `xml:"province"`
+			Citycode         string `xml:"citycode"`
+			City             string `xml:"city"`
+			District         string `xml:"district"`
+			Adcode           string `xml:"adcode"`
+			Street           string `xml:"street"`
+			Number           string `xml:"number"`
+			Location         string `xml:"location"`
+			Level            string `xml:"level"`
+		} `xml:"geocodes>geocode"`
+		Regeocode struct {
+			FormattedAddress string `xml:"formatted_address"`
+			AddressComponent struct {
+				Country      string `xml:"country"`
+				Township     string `xml:"township"`
+				District     string `xml:"district"`
+				Adcode       string `xml:"adcode"`
+				Province     string `xml:"province"`
+				Citycode     string `xml:"citycode"`
+				StreetNumber struct {
+					Number    string `xml:"number"`
+					Location  string `xml:"location"`
+					Direction string `xml:"direction"`
+					Distance  string `xml:"distance"`
+					Street    string `xml:"street"`
+				} `xml:"streetNumber"`
+			} `xml:"addressComponent"`
+		} `xml:"regeocode"`
+	}
+)
+
+const (
+	statusOK = 1
+)
+
+var r = 1000
+
+// Geocoder constructs AMAP geocoder
+func Geocoder(key string, radius int, baseURLs ...string) geo.Geocoder {
+	if radius > 0 {
+		r = radius
+	}
+	return geo.HTTPGeocoder{
+		EndpointBuilder:       baseURL(getURL(key, baseURLs...)),
+		ResponseParserFactory: func() geo.ResponseParser { return &geocodeResponse{} },
+		ResponseUnmarshaler:   &geo.XMLUnmarshaler{},
+	}
+}
+
+func getURL(apiKey string, baseURLs ...string) string {
+	if len(baseURLs) > 0 {
+		return baseURLs[0]
+	}
+	return fmt.Sprintf("https://restapi.amap.com/v3/geocode/*?key=%s&", apiKey)
+}
+
+// GeocodeURL https://restapi.amap.com/v3/geocode/geo?&output=XML&key=APPKEY&address=ADDRESS
+func (b baseURL) GeocodeURL(address string) string {
+	return strings.Replace(string(b), "*", "geo", 1) + fmt.Sprintf("output=XML&address=%s", address)
+}
+
+// ReverseGeocodeURL https://restapi.amap.com/v3/geocode/regeo?output=XML&key=APPKEY&radius=1000&extensions=all&location=31.225696563611,121.49884033194
+func (b baseURL) ReverseGeocodeURL(l geo.Location) string {
+	return strings.Replace(string(b), "*", "regeo", 1) + fmt.Sprintf("output=XML&location=%f,%f&radius=%d&extensions=all", l.Lng, l.Lat, r)
+}
+
+func (r *geocodeResponse) Location() (*geo.Location, error) {
+	var location = &geo.Location{}
+	if len(r.Geocodes) == 0 {
+		return nil, nil
+	}
+	if r.Status != statusOK {
+		return nil, fmt.Errorf("geocoding error: %v", r.Status)
+	}
+	fmt.Sscanf(string(r.Geocodes[0].Location), "%f,%f", &location.Lng, &location.Lat)
+	return location, nil
+}
+
+func (r *geocodeResponse) Address() (*geo.Address, error) {
+	if r.Status != statusOK {
+		return nil, fmt.Errorf("reverse geocoding error: %v", r.Status)
+	}
+
+	addr := parseAmapResult(r)
+
+	return addr, nil
+}
+
+func parseAmapResult(r *geocodeResponse) *geo.Address {
+	addr := &geo.Address{}
+	res := r.Regeocode
+	addr.FormattedAddress = string(res.FormattedAddress)
+	addr.HouseNumber = string(res.AddressComponent.StreetNumber.Number)
+	addr.Street = string(res.AddressComponent.StreetNumber.Street)
+	addr.Suburb = string(res.AddressComponent.District)
+	addr.State = string(res.AddressComponent.Province)
+	addr.Country = string(res.AddressComponent.Country)
+
+	if (*addr == geo.Address{}) {
+		return nil
+	}
+	return addr
+}

--- a/amap/amap_test.go
+++ b/amap/amap_test.go
@@ -1,0 +1,62 @@
+package amap_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/codingsince1985/geo-golang"
+	"github.com/codingsince1985/geo-golang/amap"
+	"github.com/stretchr/testify/assert"
+)
+
+var key = os.Getenv("AMAP_APP_KEY")
+
+func TestGeocode(t *testing.T) {
+	ts := testServer(response1)
+	defer ts.Close()
+
+	geocoder := amap.Geocoder(key, 1000, ts.URL+"/")
+	location, err := geocoder.Geocode("北京市海淀区清河街道西二旗西路领秀新硅谷")
+
+	assert.NoError(t, err)
+	assert.NotNil(t, location)
+	if location != nil {
+		assert.Equal(t, geo.Location{Lat: 40.055106, Lng: 116.309866}, *location)
+	}
+}
+
+func TestReverseGeocode(t *testing.T) {
+	ts := testServer(response2)
+	defer ts.Close()
+
+	geocoder := amap.Geocoder(key, 1000, ts.URL+"/")
+	address, err := geocoder.ReverseGeocode(116.3084202915042, 116.3084202915042)
+
+	assert.NoError(t, err)
+	assert.Equal(t, address.FormattedAddress, "北京市海淀区上地街道树村郊野公园")
+}
+
+func TestReverseGeocodeWithNoResult(t *testing.T) {
+	ts := testServer(response3)
+	defer ts.Close()
+
+	geocoder := amap.Geocoder(key, 1000, ts.URL+"/")
+	addr, err := geocoder.ReverseGeocode(-37.81375, 164.97176)
+
+	assert.NoError(t, err)
+	assert.Nil(t, addr)
+}
+
+func testServer(response string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+		resp.Write([]byte(response))
+	}))
+}
+
+const (
+	response1 = `<?xml version="1.0" encoding="UTF-8"?><response><status>1</status><info>OK</info><infocode>10000</infocode><count>1</count><geocodes type="list"><geocode><formatted_address>北京市海淀区清河街道西二旗西路领秀新硅谷</formatted_address><country>中国</country><province>北京市</province><citycode>010</citycode><city>北京市</city><district>海淀区</district><township></township><neighborhood><name></name><type></type></neighborhood><building><name></name><type></type></building><adcode>110108</adcode><street>西二旗西路</street><number></number><location>116.309866,40.055106</location><level>住宅区</level></geocode></geocodes></response>`
+	response2 = `<?xml version="1.0" encoding="UTF-8"?><response><status>1</status><info>OK</info><infocode>10000</infocode><regeocode><formatted_address>北京市海淀区上地街道树村郊野公园</formatted_address><addressComponent><country>中国</country><province>北京市</province><city></city><citycode>010</citycode><district>海淀区</district><adcode>110108</adcode><township>上地街道</township><towncode>110108022000</towncode><neighborhood><name></name><type></type></neighborhood><building><name>树村郊野公园</name><type>风景名胜;公园广场;公园</type></building><streetNumber><street>马连洼北路</street><number>29号</number><location>116.299587,40.034620</location><direction>北</direction><distance>147.306</distance></streetNumber><businessAreas type="list"><businessArea><location>116.303276,40.035542</location><name>上地</name><id>110108</id></businessArea><businessArea><location>116.256057,40.054273</location><name>西北   </name><id>110108</id></businessArea><businessArea><location>116.281156,40.028654</location><name>马连洼</name><id>110108</id></businessArea></businessAreas></addressComponent></regeocode></response>`
+	response3 = `<?xml version="1.0" encoding="UTF-8"?><response><status>1</status><info>OK</info><infocode>10000</infocode><regeocode><formatted_address></formatted_address><addressComponent><country></country><province></province><city></city><citycode></citycode><district></district><adcode></adcode><township></township><towncode></towncode></addressComponent><pois type="list"/><roads type="list"/><roadinters type="list"/><aois type="list"/></regeocode></response>`
+)

--- a/examples/geocoder_example.go
+++ b/examples/geocoder_example.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/codingsince1985/geo-golang"
+	"github.com/codingsince1985/geo-golang/amap"
 	"github.com/codingsince1985/geo-golang/arcgis"
 	"github.com/codingsince1985/geo-golang/baidu"
 	"github.com/codingsince1985/geo-golang/bing"
@@ -26,12 +27,14 @@ import (
 )
 
 const (
-	addr         = "Melbourne VIC"
-	lat, lng     = -37.813611, 144.963056
-	radius       = 50
-	zoom         = 18
-	addrFR       = "Champs de Mars Paris"
-	latFR, lngFR = 48.854395, 2.304770
+	addr             = "Melbourne VIC"
+	lat, lng         = -37.813611, 144.963056
+	radius           = 50
+	zoom             = 18
+	addrFR           = "Champs de Mars Paris"
+	addrAmap         = "北京市海淀区清河街道西二旗西路领秀新硅谷" // China only
+	latFR, lngFR     = 48.854395, 2.304770
+	latAmap, lngAmap = 40.05510, 116.309866
 )
 
 func main() {
@@ -60,6 +63,9 @@ func ExampleGeocoder() {
 
 	fmt.Println("Baidu Geocoding API")
 	try(baidu.Geocoder(os.Getenv("BAIDU_API_KEY"), "en", "bd09ll"))
+
+	fmt.Println("Amap Geocoding API")
+	tryOnlyForAmap(amap.Geocoder(os.Getenv("AMAP_API_KEY"), radius))
 
 	fmt.Println("Mapbox API")
 	try(mapbox.Geocoder(os.Getenv("MAPBOX_API_KEY")))
@@ -145,6 +151,11 @@ func ExampleGeocoder() {
 	// Address of (-37.813611,144.963056) is 341 Little Bourke Street, Melbourne, Victoria, Australia
 	// Detailed address: &geo.Address{FormattedAddress:"341 Little Bourke Street, Melbourne, Victoria, Australia", Street:"Little Bourke Street", HouseNumber:"341", Suburb:"", Postcode:"", State:"Victoria", StateCode:"", StateDistrict:"", County:"", Country:"Australia", CountryCode:"AUS", City:"Melbourne"}
 	//
+	// Amap Geocoding API
+	// 北京市海淀区清河街道西二旗西路领秀新硅谷 location is (40.05510, 116.309866)
+	// Address of (40.05510, 116.309866) is 北京市海淀区清河街道领秀新硅谷领秀新硅谷B区
+	// Detailed address: &geo.Address{FormattedAddress:"北京市海淀区清河街道领秀新硅谷领秀新硅谷B区", Street:"西二旗西路", HouseNumber:"2号楼", Suburb:"海 淀区", Postcode:"", State:"北京市", StateCode:"", StateDistrict:"", County:"", Country:"中国", CountryCode:"", City:""}
+	//
 	// Mapbox API
 	// Melbourne VIC location is (-37.814200, 144.963200)
 	// Address of (-37.813611,144.963056) is Elwood Park Playground, Melbourne, Victoria 3000, Australia
@@ -222,6 +233,23 @@ func try(geocoder geo.Geocoder) {
 		fmt.Println("got <nil> location")
 	}
 	address, _ := geocoder.ReverseGeocode(lat, lng)
+	if address != nil {
+		fmt.Printf("Address of (%.6f,%.6f) is %s\n", lat, lng, address.FormattedAddress)
+		fmt.Printf("Detailed address: %#v\n", address)
+	} else {
+		fmt.Println("got <nil> address")
+	}
+	fmt.Print("\n")
+}
+
+func tryOnlyForAmap(geocoder geo.Geocoder) {
+	location, _ := geocoder.Geocode(addrAmap)
+	if location != nil {
+		fmt.Printf("%s location is (%.6f, %.6f)\n", addr, location.Lat, location.Lng)
+	} else {
+		fmt.Println("got <nil> location")
+	}
+	address, _ := geocoder.ReverseGeocode(latAmap, lngAmap)
 	if address != nil {
 		fmt.Printf("Address of (%.6f,%.6f) is %s\n", lat, lng, address.FormattedAddress)
 		fmt.Printf("Detailed address: %#v\n", address)

--- a/http_geocoder.go
+++ b/http_geocoder.go
@@ -3,6 +3,7 @@ package geo
 import (
 	"context"
 	"encoding/json"
+	"encoding/xml"
 	"errors"
 	"io"
 	"net/http"
@@ -37,10 +38,15 @@ type ResponseParser interface {
 type HTTPGeocoder struct {
 	EndpointBuilder
 	ResponseParserFactory
+	ResponseUnmarshaler
 }
 
 func (g HTTPGeocoder) GeocodeWithContext(ctx context.Context, address string) (*Location, error) {
 	responseParser := g.ResponseParserFactory()
+	var responseUnmarshaler ResponseUnmarshaler = &JSONUnmarshaler{}
+	if g.ResponseUnmarshaler != nil {
+		responseUnmarshaler = g.ResponseUnmarshaler
+	}
 
 	type geoResp struct {
 		l *Location
@@ -49,7 +55,7 @@ func (g HTTPGeocoder) GeocodeWithContext(ctx context.Context, address string) (*
 	ch := make(chan geoResp, 1)
 
 	go func(ch chan geoResp) {
-		if err := response(ctx, g.GeocodeURL(url.QueryEscape(address)), responseParser); err != nil {
+		if err := response(ctx, g.GeocodeURL(url.QueryEscape(address)), responseUnmarshaler, responseParser); err != nil {
 			ch <- geoResp{
 				l: nil,
 				e: err,
@@ -82,6 +88,10 @@ func (g HTTPGeocoder) Geocode(address string) (*Location, error) {
 // ReverseGeocode returns address for location
 func (g HTTPGeocoder) ReverseGeocode(lat, lng float64) (*Address, error) {
 	responseParser := g.ResponseParserFactory()
+	var responseUnmarshaler ResponseUnmarshaler = &JSONUnmarshaler{}
+	if g.ResponseUnmarshaler != nil {
+		responseUnmarshaler = g.ResponseUnmarshaler
+	}
 
 	ctx, cancel := context.WithTimeout(context.TODO(), DefaultTimeout)
 	defer cancel()
@@ -93,7 +103,7 @@ func (g HTTPGeocoder) ReverseGeocode(lat, lng float64) (*Address, error) {
 	ch := make(chan revResp, 1)
 
 	go func(ch chan revResp) {
-		if err := response(ctx, g.ReverseGeocodeURL(Location{lat, lng}), responseParser); err != nil {
+		if err := response(ctx, g.ReverseGeocodeURL(Location{lat, lng}), responseUnmarshaler, responseParser); err != nil {
 			ch <- revResp{
 				a: nil,
 				e: err,
@@ -115,8 +125,28 @@ func (g HTTPGeocoder) ReverseGeocode(lat, lng float64) (*Address, error) {
 	}
 }
 
+type ResponseUnmarshaler interface {
+	Unmarshal(data []byte, v any) error
+}
+
+type JSONUnmarshaler struct{}
+
+func (*JSONUnmarshaler) Unmarshal(data []byte, v any) error {
+	body := strings.Trim(string(data), " []")
+	if body == "" {
+		return nil
+	}
+	return json.Unmarshal([]byte(body), v)
+}
+
+type XMLUnmarshaler struct{}
+
+func (*XMLUnmarshaler) Unmarshal(data []byte, v any) error {
+	return xml.Unmarshal(data, v)
+}
+
 // Response gets response from url
-func response(ctx context.Context, url string, obj ResponseParser) error {
+func response(ctx context.Context, url string, unmarshaler ResponseUnmarshaler, obj ResponseParser) error {
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return err
@@ -136,12 +166,8 @@ func response(ctx context.Context, url string, obj ResponseParser) error {
 		return err
 	}
 
-	body := strings.Trim(string(data), " []")
-	DebugLogger.Printf("Received response: %s\n", body)
-	if body == "" {
-		return nil
-	}
-	if err := json.Unmarshal([]byte(body), obj); err != nil {
+	DebugLogger.Printf("Received response: %s\n", string(data))
+	if err := unmarshaler.Unmarshal(data, obj); err != nil {
 		ErrLogger.Printf("Error unmarshalling response: %s\n", err.Error())
 		return err
 	}


### PR DESCRIPTION
This pull request adds support for Amap (Gaode) to the geo-golang library. Amap is a widely used mapping and geolocation service in China, and integrating it into geo-golang expands the library's capabilities for users who need geolocation services in this region.

Key Changes:

Implemented an Amap geocoder.

Added support for Amap's API, including forward and reverse geocoding.

Included necessary configuration options for Amap API keys.

Updated documentation to include usage instructions for Amap integration.

Added tests to validate the functionality of Amap geocoding.

Why is this needed?
Amap is one of the most commonly used geolocation services in China, and currently, geo-golang lacks direct support for it. This addition allows developers to leverage Amap's geolocation services seamlessly within their Go applications.

Testing Details:

Unit tests have been added to verify the correctness of Amap geocoding responses.

Manual testing was conducted using valid Amap API keys to ensure proper integration.

Notes:

Users need to obtain an Amap API key and configure it appropriately before using this feature.

Additional error handling has been implemented to manage API request limits and invalid responses.

Please review and let me know if any modifications or improvements are needed. 

Thank you!