### PR TITLE
Add ip2geo IP geolocation provider

### DIFF
--- a/ip2geo/geocoder.go
+++ b/ip2geo/geocoder.go
@@ -1,0 +1,130 @@
+// Package ip2geo is a geo-golang based ip2geo.dev IP geolocation client
+package ip2geo
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/codingsince1985/geo-golang"
+)
+
+type geocoder struct {
+	apiKey  string
+	baseURL string
+}
+
+type apiResponse struct {
+	Success bool   `json:"success"`
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    struct {
+		IP        string `json:"ip"`
+		Type      string `json:"type"`
+		Continent struct {
+			Name    string `json:"name"`
+			Code    string `json:"code"`
+			Country struct {
+				Name        string `json:"name"`
+				Code        string `json:"code"`
+				PhoneCode   string `json:"phone_code"`
+				Capital     string `json:"capital"`
+				Subdivision struct {
+					Name string `json:"name"`
+					Code string `json:"code"`
+				} `json:"subdivision"`
+				City struct {
+					Name           string  `json:"name"`
+					Latitude       float64 `json:"latitude"`
+					Longitude      float64 `json:"longitude"`
+					PostalCode     string  `json:"postal_code"`
+					AccuracyRadius int     `json:"accuracy_radius"`
+					Timezone       struct {
+						Name string `json:"name"`
+					} `json:"timezone"`
+				} `json:"city"`
+			} `json:"country"`
+		} `json:"continent"`
+		ASN struct {
+			Number int    `json:"number"`
+			Name   string `json:"name"`
+		} `json:"asn"`
+		RegisteredCountry struct {
+			Name string `json:"name"`
+			Code string `json:"code"`
+		} `json:"registered_country"`
+	} `json:"data"`
+}
+
+// Geocoder constructs an ip2geo geocoder
+func Geocoder(apiKey string, baseURLs ...string) geo.Geocoder {
+	baseURL := "https://api.ip2geo.dev"
+	if len(baseURLs) > 0 {
+		baseURL = baseURLs[0]
+	}
+	return &geocoder{apiKey: apiKey, baseURL: baseURL}
+}
+
+// Geocode returns location for the given IP address
+func (g *geocoder) Geocode(address string) (*geo.Location, error) {
+	resp, err := g.fetch(address)
+	if err != nil {
+		return nil, err
+	}
+
+	if !resp.Success {
+		return nil, errors.New("ip2geo: " + resp.Message)
+	}
+
+	city := resp.Data.Continent.Country.City
+	if city.Latitude == 0 && city.Longitude == 0 {
+		return nil, nil
+	}
+
+	return &geo.Location{
+		Lat: city.Latitude,
+		Lng: city.Longitude,
+	}, nil
+}
+
+// ReverseGeocode returns address for location.
+// ip2geo is an IP geolocation service and does not support reverse geocoding.
+func (g *geocoder) ReverseGeocode(lat, lng float64) (*geo.Address, error) {
+	return nil, errors.New("ip2geo: reverse geocoding is not supported")
+}
+
+func (g *geocoder) fetch(ip string) (*apiResponse, error) {
+	reqURL := g.baseURL + "/convert?ip=" + url.QueryEscape(ip)
+
+	ctx, cancel := context.WithTimeout(context.Background(), geo.DefaultTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("X-Api-Key", g.apiKey)
+	req.Header.Set("User-Agent", "geo-golang/1.0")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var result apiResponse
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}

--- a/ip2geo/geocoder_test.go
+++ b/ip2geo/geocoder_test.go
@@ -1,0 +1,142 @@
+package ip2geo_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/codingsince1985/geo-golang/ip2geo"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGeocode(t *testing.T) {
+	ts := testServer(response1)
+	defer ts.Close()
+
+	geocoder := ip2geo.Geocoder("test-key", ts.URL)
+	location, err := geocoder.Geocode("134.201.250.155")
+	assert.NoError(t, err)
+	assert.NotNil(t, location)
+	assert.InDelta(t, 34.0544, location.Lat, 0.01)
+	assert.InDelta(t, -118.244, location.Lng, 0.01)
+}
+
+func TestGeocodeNoCity(t *testing.T) {
+	ts := testServer(responseNoCity)
+	defer ts.Close()
+
+	geocoder := ip2geo.Geocoder("test-key", ts.URL)
+	location, err := geocoder.Geocode("8.8.8.8")
+	assert.NoError(t, err)
+	assert.NotNil(t, location)
+	assert.InDelta(t, 37.751, location.Lat, 0.01)
+	assert.InDelta(t, -97.822, location.Lng, 0.01)
+}
+
+func TestGeocodeError(t *testing.T) {
+	ts := testServer(responseError)
+	defer ts.Close()
+
+	geocoder := ip2geo.Geocoder("bad-key", ts.URL)
+	location, err := geocoder.Geocode("8.8.8.8")
+	assert.Error(t, err)
+	assert.Nil(t, location)
+}
+
+func TestReverseGeocode(t *testing.T) {
+	geocoder := ip2geo.Geocoder("test-key")
+	address, err := geocoder.ReverseGeocode(34.0, -118.0)
+	assert.Error(t, err)
+	assert.Nil(t, address)
+}
+
+func TestGeocodeVerifiesHeader(t *testing.T) {
+	var receivedKey string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedKey = r.Header.Get("X-Api-Key")
+		w.Write([]byte(response1))
+	}))
+	defer ts.Close()
+
+	geocoder := ip2geo.Geocoder("my-secret-key", ts.URL)
+	geocoder.Geocode("134.201.250.155")
+	assert.Equal(t, "my-secret-key", receivedKey)
+}
+
+func testServer(response string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(response))
+	}))
+}
+
+var response1 string
+var responseNoCity string
+var responseError string
+
+func init() {
+	r1, _ := json.Marshal(map[string]interface{}{
+		"success": true,
+		"code":    200,
+		"data": map[string]interface{}{
+			"ip":   "134.201.250.155",
+			"type": "ipv4",
+			"continent": map[string]interface{}{
+				"name": "North America",
+				"code": "na",
+				"country": map[string]interface{}{
+					"name": "United States",
+					"code": "us",
+					"subdivision": map[string]interface{}{
+						"name": "California",
+						"code": "CA",
+					},
+					"city": map[string]interface{}{
+						"name":        "Los Angeles",
+						"latitude":    34.0544,
+						"longitude":   -118.244,
+						"postal_code": "90060",
+						"timezone": map[string]interface{}{
+							"name": "America/Los_Angeles",
+						},
+					},
+				},
+			},
+			"asn": map[string]interface{}{
+				"number": 25876,
+				"name":   "Los Angeles Department Of Water & Power",
+			},
+		},
+	})
+	response1 = string(r1)
+
+	r2, _ := json.Marshal(map[string]interface{}{
+		"success": true,
+		"code":    200,
+		"data": map[string]interface{}{
+			"ip":   "8.8.8.8",
+			"type": "ipv4",
+			"continent": map[string]interface{}{
+				"name": "North America",
+				"code": "na",
+				"country": map[string]interface{}{
+					"name": "United States",
+					"code": "us",
+					"city": map[string]interface{}{
+						"latitude":  37.751,
+						"longitude": -97.822,
+					},
+				},
+			},
+		},
+	})
+	responseNoCity = string(r2)
+
+	r3, _ := json.Marshal(map[string]interface{}{
+		"success": false,
+		"code":    401,
+		"message": "Invalid API key",
+	})
+	responseError = string(r3)
+}


### PR DESCRIPTION
## Summary

Adds a new provider for the [ip2geo](https://ip2geo.dev) IP geolocation API. This is an **IP address geocoder** — it takes IP addresses (IPv4/IPv6) and returns geographic coordinates.

Implements the `Geocoder` interface directly (rather than `HTTPGeocoder`) to support API key authentication via `X-Api-Key` header, which the standard `response()` function doesn't support.

## Usage

```go
geocoder := ip2geo.Geocoder("your-api-key")

location, err := geocoder.Geocode("134.201.250.155")
// location.Lat = 34.0544, location.Lng = -118.244
```

`ReverseGeocode` returns an error since IP geolocation is forward-only.

## Files added

- `ip2geo/geocoder.go` — provider implementation
- `ip2geo/geocoder_test.go` — unit tests with mocked HTTP server

## Test plan

- [x] `go build ./ip2geo/` compiles successfully
- [x] `go test ./ip2geo/ -v` — 5/5 tests pass (geocode, no-city IP, error handling, reverse error, header verification)
- [x] Live API: `Geocode("134.201.250.155")` returns (34.0544, -118.244)
- [x] Live API: `Geocode("8.8.8.8")` returns (37.751, -97.822)
- [x] X-Api-Key header verified via test server mock